### PR TITLE
Report coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,12 @@ jobs:
     environment:
       GO111MODULE=on
     steps:
-      - checkout
 
+      - checkout
       - run: make
+
+      - add_ssh_keys:
+          fingerprints:
+            - f4:3f:d8:d7:4f:53:e9:2f:03:55:e9:28:8d:7e:dc:bc
+
+      - run: make update-coverage-badge

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ export GO111MODULE := on
 
 SCAFFOLD_BIN := bin/scaffold
 PACKR_FILE := pkg/scaffold/scaffold-packr.go
+COVERAGE_PERCENT_FILE := build/coverage-percent.txt
 
 ASSETS := $(shell find templates/scaffold)
 
@@ -41,7 +42,7 @@ test: output-coverage
 
 .PHONY: output-coverage
 output-coverage: $(MERGED_COVERAGE) $(HTML_COVERAGE)
-	go tool cover -func=$<
+	go tool cover -func=$< | sed -e 's/total:[[:space:]]*(statements)[[:space:]]*\([0-9.]*\)%/\1/gw $(COVERAGE_PERCENT_FILE)'
 
 $(MERGED_COVERAGE): $(COVERAGE)
 ifndef HAS_GOCOVERUTIL
@@ -63,4 +64,4 @@ $(COVERAGE):
 .PHONY: clean
 clean:
 	packr2 clean
-	rm -r bin
+	rm -r bin build

--- a/Makefile
+++ b/Makefile
@@ -42,37 +42,46 @@ MERGED_COVERAGE := build/coverage/report/cover.merged.out
 HTML_COVERAGE := build/coverage/html/index.html
 
 .PHONY: test
-test: output-coverage
+test: clean-coverage output-coverage
+
+.PHONY: clean-coverage
+clean-coverage:
+	rm -f $(COVERAGE)
 
 .PHONY: output-coverage
 output-coverage: $(MERGED_COVERAGE) $(HTML_COVERAGE)
-	go tool cover -func=$< | sed -e 's/total:[[:space:]]*(statements)[[:space:]]*\([0-9.]*\)%/\1/gw $(COVERAGE_PERCENT_FILE)'
+	go tool cover -func=$<
+
+$(COVERAGE_PERCENT_FILE): $(MERGED_COVERAGE)
+	go tool cover -func=$< | sed -n 's/total:[[:space:]]*(statements)[[:space:]]*\([0-9.]*\)%/\1/gw $@'
 
 $(MERGED_COVERAGE): $(COVERAGE)
 ifndef HAS_GOCOVERUTIL
 	gobin github.com/AlekSi/gocoverutil@v0.2.0
 endif
-	$(call msg,Generating merged coverage report)
 	gocoverutil -coverprofile=$@ merge $^
 
 $(HTML_COVERAGE): $(MERGED_COVERAGE)
 	@mkdir -p $(@D)
 	go tool cover -html=$< -o $@
 
-.PHONY: $(COVERAGE)
 $(COVERAGE):
 	@mkdir -p $(@D)
-	$(call msg,--> Testing $(@F)...)
 	go test ./$(@F)/... --cover -coverprofile $@ -v
 
 .PHONY: update-coverage-badge
-update-coverage-badge:
+update-coverage-badge: $(COVERAGE_PERCENT_FILE)
+ifneq ("$(CIRCLE_BRANCH)","master")
+	@echo
+	@echo "On branch $(CIRCLE_BRANCH), not publishing this branch's $$(cat $(COVERAGE_PERCENT_FILE))% total coverage."
+else
 	rm -rf /tmp/$(DOC_REPO_NAME)
 	git -C /tmp clone $(DOC_REPO)
 	cd /tmp/$(DOC_REPO_NAME) && \
 	go run github.com/davidovich/summon-example-assets/summon shields.io/coverage.json.gotmpl --json "{\"Coverage\": \"$$(cat $(COVERAGE_PERCENT_FILE))\"}" -o- > /tmp/$(SUMMON_BADGE_JSON_FILE)
 	git -C /tmp/$(DOC_REPO_NAME) diff-index --quiet HEAD || git -C /tmp/$(DOC_REPO_NAME) -c user.email=automation@davidovich.com -c user.name=automation commit -am "automated coverage commit of $$(cat $(COVERAGE_PERCENT_FILE)) %" || true
 	git -C /tmp/$(DOC_REPO_NAME) push
+endif
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Automate generation and commit of current coverage using github pages.

Uses summon to instantiate a [shields.io/coverage.json.tmpl](https://github.com/davidovich/summon-example-assets/blob/v0.4.1/assets/shields.io/coverage.json.gotmpl) file with correct values, hosted at davidovich.github.io/shields/summon/summon.json.

Current thresholds: 

* green >= 80% 
* yellow >= 70%
* red < 70%