### PR TITLE
adds args,osArgs predefined data for config tmpl

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,30 +309,37 @@ Here, when you run with the `echo` handle, the arrays will be flattened to produ
 
 > New in v0.12.0
 
-Summon provisions `.args` and `.osArgs` as slices of arguments. You can use
+Summon provisions the `args`, `arg` functions and `.osArgs` slice of arguments. You can use
 these in a template of the params array.
 
-* `.args` will contain unknown args passed from the command-line (see `ls` handle
+* `args` will contain unknown args passed from the command-line (see `ls` handle
   defined in the [config section](#/summon-config-file))
 
     ```bash
     summon run ls -al
-                 [ ^ .args array starts here ]
+                 [ ^ args array starts here ]
     ```
 
-    Here, `.args` would contain `[-al]`.
+    Here, `{{ args }}` would return `[-al]`.
 
-    When used, summon will disable appending user args, as this would
-    surprisingly double the args.
+* `arg` allows accessing one arg, with an error message if arg is not found
 
     ```yaml
     ...
     exec:
        bash -c:
-          ls: [ls, '{{ index .args 0}}']
+          ls: [ls, '{{ arg 0 "error msg" }}']
     ```
 
+When used, summon will remove the consumed args, as this would
+surprisingly double the args. In other words, when accessing `{{ args }}`,
+summon will not append the resulting args, and using `{{ arg 0 "error" }}`,
+summon would only append the unconsumed args (after index 0).
+
 * `.osArgs` contains the whole command-line slice
+
+If the result of using args is a string representation of an array, like
+`[a b c d]` this array will be flattened to the final args array.
 
 ### Dump the Data at a Location
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ outputdir: .summoned
 aliases:
     simple-handle: a/file/in/asset-dir
 
+templates: |
+  {{/* new starting at v0.12.0, global templates available to command params */}}
+  {{- define "maybeChangeUser" -}}
+    {{- if (env "SUMMON_CHANGE_USER") -}}
+      -u {{ env "SUMMON_CHANGE_USER" }}
+    {{- end -}}
+  {{- end -}}
+
 # exec section declares invokables with their handle
 # a same handle name cannot be in two invokers at the same time
 # they are grouped by invoker.
@@ -98,7 +106,7 @@ exec:
         # (script can be inlined with | yaml operator)
         hello: [echo, hello]
                  # ^ optional params that will be passed to invoker
-                 # these can contain templates (in v0.10.0)
+                 # these can contain templates (starting at v0.10.0)
         # ^ handle to script (must be unique). This is what you use
         # to invoke the script: `summon run hello`.
 
@@ -108,6 +116,15 @@ exec:
 
     python -c:
         hello-python: [print("hello from python!")]
+
+    # Expose docker containers commands without having
+    # to remember mounting volumes, etc.
+    # `?` YAML construct allows multi-line keys for easier reading
+    ? docker run -ti --rm -w /{{ env "PWD" | base }}
+      -v {{ env "PWD" }}:/{{ env "PWD" | base }}
+      {{ template "maybeChangeUser" }}
+      alpine
+    : ls: [ls]
 ```
 
 You can invoke executables like so:
@@ -138,8 +155,15 @@ In an empty asset data repository directory:
 ## Install
 
 Install (using gobin) the asset repo which will become the summon executable.
-If the consumer site needs to version the data alonside the consumer (each site could have a specific version of data),
-you have two alternatives:
+You have these alternatives:
+
+* change to a directory that does not contain a go.mod. This installs globally:
+
+```bash
+cd /tmp
+GO111MODULE=on go get [your-go-repo-import]/summon[@wanted-version-or-branch]
+cd -
+```
 
 * use gobin to install summon in the consuming site:
 
@@ -148,8 +172,6 @@ GO111MODULE=off go get -u github.com/myitcv/gobin
 # install the data repository as summon executable at the site
 GOBIN=./ gobin [your-go-repo-import]/summon[@wanted-version-or-branch]
 ```
-
-* declare a [tools.go](https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module) file (will update when I get to testing this).
 
 ## Use-cases
 
@@ -218,11 +240,11 @@ will yield:
 `summon run [executable]` allows to run executables declared in the
 [config file](#/summon-config-file).
 
-> New in v0.10.0, you can use go templates in the `exec:` section.
+> New in v0.10.0:
+> * you can use go templates in the `exec:` section.
+> * you can summon embedded data in the `exec:` section.
 
-> New in v0.10.0, you can summon embedded data in the `exec:` section.
-
-#### Templated invokables
+#### Templated Invokables
 
 Suppose you want to make a wrapper around a docker utility. The specific
 docker invocation can be quite cryptic. Help your team by adding an invokable
@@ -239,7 +261,7 @@ Calling `summon run list` would render the [{{ env "PWD" }}](https://masterminds
 
 `docker run -v [working-dir]:/mounted-app alpine ls /mounted-app`
 
-#### Templated references
+#### Templated References
 
 Say you would like to bundle a script in the data repo and also use it as an
 invocable (new in v.0.10.0). You would use the `summon` template function bundled in summon:
@@ -259,7 +281,60 @@ bash -c /tmp/hello.sh
 > Note that `hello.sh` could also contain templates that will be
 rendered at instanciation time.
 
-### Dumping the Data at a Location
+#### Keeping DRY
+
+> New in v0.12.0
+
+Sometimes you will use Summon as a proxy on a docker container. Some
+parameters will always need to be passed (volume mounts for example). You
+can use YAML anchors to define the static (but required) params in
+`summon.config.yaml`:
+
+
+```yaml
+.base: &baseargs
+    - echo
+    - b
+    - c
+
+exec:
+    bash -c:
+      echo: [*baseargs, d]
+```
+
+Here, when you run with the `echo` handle, the arrays will be flattened to produce
+`[echo, b, c, d]` for the construction of the command.
+
+#### Using Args
+
+> New in v0.12.0
+
+Summon provisions `.args` and `.osArgs` as slices of arguments. You can use
+these in a template of the params array.
+
+* `.args` will contain unknown args passed from the command-line (see `ls` handle
+  defined in the [config section](#/summon-config-file))
+
+    ```bash
+    summon run ls -al
+                 [ ^ .args array starts here ]
+    ```
+
+    Here, `.args` would contain `[-al]`.
+
+    When used, summon will disable appending user args, as this would
+    surprisingly double the args.
+
+    ```yaml
+    ...
+    exec:
+       bash -c:
+          ls: [ls, '{{ index .args 0}}']
+    ```
+
+* `.osArgs` contains the whole command-line slice
+
+### Dump the Data at a Location
 
 ```bash
 summon --all --out .dir
@@ -285,6 +360,15 @@ summon ls
 summon ls --tree # pretty print hierarchy
 ```
 
+### Evaluate what will be run (--dry-run)
+
+> New in v0.10.0
+
+```bash
+summon run -n ls -al
+Would execute `/usr/local/bin/docker run -ti --rm -w /application -v [current-dir]:/application alpine ls -al`...
+```
+
 ### View Data Version Information
 
 ```bash
@@ -299,21 +383,36 @@ summon -v
 source <(summon completion)
 ```
 
-## Alternatives
+## TODO
 
-Why not use git directly?
+* [ ] Add a `required` template function to enforce `.args` presence, and error
+  with a message.
+* [ ] Add help documentation for proxied commands
+* [ ] Explore ways to hook completions from proxied commands.
 
-While you could use git directly to bring an asset directory with a simple git clone, the result does not have executable properties.
+## FAQ
 
-In summon you leverage go execution to bootstrap in one phase. So your data can do:
+* Why is the `exec:` config file ordered by "invoker" ?
 
-```bash
-go run github.com/davidovich/summon-example-assets/summon --help
-# or list the data deliverables
-go run github.com/davidovich/summon-example-assets/summon ls
-# or
-# let summon configure the path so it can invoke a go executable
-# (here go-gettable-executable is a reference to a go gettable repo), and will
-# result in an executable tailored for your destination os and architecture (because built on the fly).
-go run github.com/davidovich/summon-example-assets/summon run go-gettable-executable
-```
+  Summon is oriented at providing an easy CLI interface to complex sub programs.
+  In this regard, it tends to group invocations in the same execution "environment".
+
+  This helps in scenarios of supplying a dev container from which are surfaced
+  tools for your team.
+
+* Why not use git directly ?
+
+  While you could use git directly to bring an asset directory with a simple git clone, the result does not have executable properties.
+
+  In summon you leverage go execution to bootstrap in one phase. So your data can do:
+
+  ```bash
+  gobin -run github.com/davidovich/summon-example-assets/summon --help
+  # or list the data deliverables
+  gobin -run github.com/davidovich/summon-example-assets/summon ls
+  # or
+  # let summon configure the path so it can invoke a go executable
+  # (here go-gettable-executable is a reference to a go gettable repo), and will
+  # result in an executable tailored for your destination os and architecture (because built on the fly).
+  gobin -run github.com/davidovich/summon-example-assets/summon run go-gettable-executable
+  ```

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -56,7 +56,8 @@ func newRunCmd(driver summon.ConfigurableRunner, main *mainCmd) *cobra.Command {
 		// We are lucky, we know the prefix order of params,
 		// extract args after the run command [summon run handle]
 		// see https://github.com/spf13/pflag/pull/160
-		// and https://github.com/spf13/cobra/issues/739
+		// https://github.com/spf13/cobra/issues/739
+		// and https://github.com/spf13/pflag/pull/199
 		runCmd.args = extractUnknownArgs(cmd.Flags(), osArgs[3:])
 		return runCmd.run()
 	}
@@ -78,7 +79,7 @@ func extractUnknownArgs(flags *pflag.FlagSet, args []string) []string {
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		var f *pflag.Flag
-		if a[0] == '-' {
+		if a[0] == '-' && len(a) > 1 {
 			if a[1] == '-' {
 				f = flags.Lookup(strings.SplitN(a[2:], "=", 2)[0])
 			} else {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -109,6 +109,12 @@ func TestExtractUnknownArgs(t *testing.T) {
 	unknown := extractUnknownArgs(fset, []string{"--json", "{}", "--unknown"})
 	assert.Equal(t, []string{"--unknown"}, unknown)
 
+	unknown = extractUnknownArgs(fset, []string{"--"})
+	assert.Equal(t, []string{"--"}, unknown)
+
 	unknownShort := extractUnknownArgs(fset, []string{"-j", "--unknown"})
 	assert.Equal(t, []string{"--unknown"}, unknownShort)
+
+	unknownShort = extractUnknownArgs(fset, []string{"-"})
+	assert.Equal(t, []string{"-"}, unknownShort)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,14 +18,15 @@ var OutputDir = DefaultOutputDir
 type Alias map[string]string
 
 // Executable describes a handle name and invocable target.
-type Executable map[string][]string
+type Executable map[string][]interface{}
 
 // Config is the summon config
 type Config struct {
-	Version     int
-	Aliases     Alias                 `yaml:"aliases"`
-	OutputDir   string                `yaml:"outputdir"`
-	Executables map[string]Executable `yaml:"exec"`
+	Version         int
+	Aliases         Alias                 `yaml:"aliases"`
+	OutputDir       string                `yaml:"outputdir"`
+	TemplateContext string                `yaml:"templates"`
+	Executables     map[string]Executable `yaml:"exec"`
 }
 
 // Unmarshal hidrates the config from config bytes.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,11 +15,11 @@ func TestConfigWriter(t *testing.T) {
 		Version: 1,
 		Executables: map[string]Executable{
 			"go": {
-				"gobin":  []string{"github.com/myitcv/gobin"},
-				"gohack": []string{"github.com/rogppepe/gohack"},
+				"gobin":  []interface{}{"github.com/myitcv/gobin"},
+				"gohack": []interface{}{"github.com/rogppepe/gohack"},
 			},
-			"bash":      {"hello-bash": []string{"hello.sh"}},
-			"python -c": {"hello": []string{"print(\"hello from python!\")"}},
+			"bash":      {"hello-bash": []interface{}{"hello.sh"}},
+			"python -c": {"hello": []interface{}{"print(\"hello from python!\")"}},
 		},
 	}
 
@@ -29,6 +29,7 @@ func TestConfigWriter(t *testing.T) {
 version: 1
 aliases: {}
 outputdir: ""
+templates: ""
 exec:
   bash:
     hello-bash:

--- a/pkg/summon/driver.go
+++ b/pkg/summon/driver.go
@@ -3,6 +3,9 @@ package summon
 import (
 	"fmt"
 	"os"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
 
 	"github.com/davidovich/summon/pkg/command"
 	"github.com/davidovich/summon/pkg/config"
@@ -17,6 +20,7 @@ type Driver struct {
 	opts        options
 	config      config.Config
 	box         *packr.Box
+	templateCtx *template.Template
 	execCommand command.ExecCommandFn
 	configRead  bool
 }
@@ -50,6 +54,14 @@ func (d *Driver) Configure(opts ...Option) error {
 				return err
 			}
 			d.opts.DefaultsFrom(d.config)
+			d.templateCtx, err = template.New("Summon").
+				Option("missingkey=zero").
+				Funcs(sprig.TxtFuncMap()).
+				Funcs(summonFuncMap(d)).
+				Parse(d.config.TemplateContext)
+			if err != nil {
+				return err
+			}
 			d.configRead = true
 		}
 	}

--- a/pkg/summon/options.go
+++ b/pkg/summon/options.go
@@ -8,7 +8,7 @@ import (
 	"github.com/davidovich/summon/pkg/config"
 )
 
-// options fir all summon commands
+// options for all summon commands
 type options struct {
 	// copy all the tree
 	all bool
@@ -22,6 +22,8 @@ type options struct {
 	ref string
 	// args to exec entry
 	args []string
+	// keep track of arg indexes that were used
+	argsConsumed map[int]struct{}
 	// template rendering data
 	data map[string]interface{}
 	// out

--- a/pkg/summon/run.go
+++ b/pkg/summon/run.go
@@ -3,6 +3,7 @@ package summon
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/google/shlex"
@@ -13,7 +14,7 @@ import (
 type execUnit struct {
 	invoker string
 	invOpts string
-	targets []string
+	targets []interface{}
 }
 
 // Run will run executable scripts described in the summon.config.yaml file
@@ -24,31 +25,49 @@ func (d *Driver) Run(opts ...Option) error {
 		return err
 	}
 
-	eu, err := d.findExecutor()
+	eu, err := d.findExecutor(d.opts.ref)
 	if err != nil {
 		return err
 	}
 
-	eu.invOpts, err = d.renderTemplate(eu.invOpts, d.opts.data)
+	data := d.opts.data
+	// add arguments
+	if data == nil {
+		data = map[string]interface{}{}
+	}
+	data["osArgs"] = os.Args
+	data["args"] = d.opts.args
+
+	invOpts, err := d.renderTemplate(eu.invOpts, data)
 	if err != nil {
 		return err
 	}
 
 	targets := make([]string, 0, len(eu.targets))
-	for _, t := range eu.targets {
-		rt, err := d.renderTemplate(t, d.opts.data)
+	suppressArgsAppend := false
+	for _, t := range FlattenStrings(eu.targets) {
+		// check if we reference args so we don't append them twice
+		// if the user uses args, he/she will find it surprising that they
+		// are also appended unconditionally
+		if strings.Contains(strings.ReplaceAll(t, " ", ""), ".args") {
+			suppressArgsAppend = true
+		}
+		rt, err := d.renderTemplate(t, data)
 		if err != nil {
 			return err
 		}
 		targets = append(targets, rt)
 	}
 
-	rargs, err := shlex.Split(eu.invOpts)
+	rargs, err := shlex.Split(invOpts)
 	if err != nil {
 		return err
 	}
 
-	rargs = append(rargs, append(targets, d.opts.args...)...)
+	rargs = append(rargs, targets...)
+	if !suppressArgsAppend {
+		rargs = append(rargs, d.opts.args...)
+	}
 
 	cmd := d.execCommand(eu.invoker, rargs...)
 
@@ -85,11 +104,11 @@ func (d *Driver) ListInvocables() []string {
 	return invocables
 }
 
-func (d *Driver) findExecutor() (execUnit, error) {
+func (d *Driver) findExecutor(ref string) (execUnit, error) {
 	eu := execUnit{}
 
 	for ex, handles := range d.config.Executables {
-		if c, ok := handles[d.opts.ref]; ok {
+		if c, ok := handles[ref]; ok {
 			exec := strings.SplitAfterN(ex, " ", 2)
 			eu.invoker = strings.TrimSpace(exec[0])
 			if len(exec) == 2 {
@@ -107,4 +126,31 @@ func (d *Driver) findExecutor() (execUnit, error) {
 	}
 
 	return eu, nil
+}
+
+func flatten(args []interface{}, v reflect.Value) []interface{} {
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+
+	if v.Kind() == reflect.Array || v.Kind() == reflect.Slice {
+		for i := 0; i < v.Len(); i++ {
+			args = flatten(args, v.Index(i))
+		}
+	} else {
+		args = append(args, v.Interface())
+	}
+
+	return args
+}
+
+// FlattenStrings takes an array of string values or string slices and returns
+// an flattened slice of strings.
+func FlattenStrings(args ...interface{}) []string {
+	flattened := flatten(nil, reflect.ValueOf(args))
+	s := make([]string, 0, len(flattened))
+	for _, f := range flattened {
+		s = append(s, f.(string))
+	}
+	return s
 }

--- a/pkg/summon/run_test.go
+++ b/pkg/summon/run_test.go
@@ -7,20 +7,23 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/davidovich/summon/internal/testutil"
 	"github.com/gobuffalo/packr/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/davidovich/summon/internal/testutil"
 )
 
 func TestRun(t *testing.T) {
 	box := packr.New("test run box", "testdata")
 
 	tests := []struct {
-		name    string
-		helper  string
-		ref     string
-		expect  string
-		wantErr bool
+		name     string
+		helper   string
+		ref      string
+		expect   string
+		contains string
+		args     []string
+		wantErr  bool
 	}{
 		{
 			name:    "composite-invoker", // python -c
@@ -62,6 +65,28 @@ func TestRun(t *testing.T) {
 			expect:  "docker info",
 			wantErr: false,
 		},
+		{
+			name:    "args access",
+			helper:  "TestSummonRunHelper",
+			ref:     "args",
+			args:    []string{"a", "b"},
+			expect:  "bash args: [a b]",
+			wantErr: false,
+		},
+		{
+			name:     "osArgs access",
+			helper:   "TestSummonRunHelper",
+			ref:      "osArgs",
+			contains: "test",
+			wantErr:  false,
+		},
+		{
+			name:     "global template render",
+			helper:   "TestSummonRunHelper",
+			ref:      "templateref",
+			contains: "bash 1.2.3",
+			wantErr:  false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -72,7 +97,7 @@ func TestRun(t *testing.T) {
 			stderr := &bytes.Buffer{}
 			s.Configure(ExecCmd(testutil.FakeExecCommand(tt.helper, stdout, stderr)))
 
-			if err := s.Run(); (err != nil) != tt.wantErr {
+			if err := s.Run(Args(tt.args...)); (err != nil) != tt.wantErr {
 				t.Errorf("summon.Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
@@ -81,8 +106,10 @@ func TestRun(t *testing.T) {
 
 			if tt.wantErr {
 				assert.Len(t, c.Calls, 0)
-			} else {
+			} else if tt.expect != "" {
 				assert.Equal(t, tt.expect, c.Calls[0].Args)
+			} else if tt.contains != "" {
+				assert.Contains(t, c.Calls[0].Args, tt.contains)
 			}
 		})
 	}
@@ -110,5 +137,5 @@ func TestListInvocables(t *testing.T) {
 	s, _ := New(box)
 
 	inv := s.ListInvocables()
-	assert.ElementsMatch(t, []string{"hello-bash", "bash-self-ref", "docker", "gobin", "gohack", "hello"}, inv)
+	assert.ElementsMatch(t, []string{"hello-bash", "bash-self-ref", "docker", "gobin", "gohack", "hello", "args", "osArgs", "templateref"}, inv)
 }

--- a/pkg/summon/run_test.go
+++ b/pkg/summon/run_test.go
@@ -82,6 +82,14 @@ func TestRun(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "all args access no remainder passed",
+			helper:  "TestSummonRunHelper",
+			ref:     "all-args",
+			args:    []string{"a", "b", "c", "d"},
+			expect:  "bash args: a b c d",
+			wantErr: false,
+		},
+		{
 			name:     "osArgs access",
 			helper:   "TestSummonRunHelper",
 			ref:      "osArgs",
@@ -145,5 +153,5 @@ func TestListInvocables(t *testing.T) {
 	s, _ := New(box)
 
 	inv := s.ListInvocables()
-	assert.ElementsMatch(t, []string{"hello-bash", "bash-self-ref", "docker", "gobin", "gohack", "hello", "args", "one-arg", "osArgs", "templateref"}, inv)
+	assert.ElementsMatch(t, []string{"hello-bash", "bash-self-ref", "docker", "gobin", "gohack", "hello", "args", "one-arg", "all-args", "osArgs", "templateref"}, inv)
 }

--- a/pkg/summon/run_test.go
+++ b/pkg/summon/run_test.go
@@ -69,8 +69,16 @@ func TestRun(t *testing.T) {
 			name:    "args access",
 			helper:  "TestSummonRunHelper",
 			ref:     "args",
-			args:    []string{"a", "b"},
-			expect:  "bash args: [a b]",
+			args:    []string{"a c", "b"},
+			expect:  "bash args: a c b",
+			wantErr: false,
+		},
+		{
+			name:    "one arg access remainder passed",
+			helper:  "TestSummonRunHelper",
+			ref:     "one-arg",
+			args:    []string{"\"acce ssed\"", "remainder1", "remainder2"},
+			expect:  "bash args: \"acce ssed\" remainder1 remainder2",
 			wantErr: false,
 		},
 		{
@@ -137,5 +145,5 @@ func TestListInvocables(t *testing.T) {
 	s, _ := New(box)
 
 	inv := s.ListInvocables()
-	assert.ElementsMatch(t, []string{"hello-bash", "bash-self-ref", "docker", "gobin", "gohack", "hello", "args", "osArgs", "templateref"}, inv)
+	assert.ElementsMatch(t, []string{"hello-bash", "bash-self-ref", "docker", "gobin", "gohack", "hello", "args", "one-arg", "osArgs", "templateref"}, inv)
 }

--- a/pkg/summon/summon.go
+++ b/pkg/summon/summon.go
@@ -8,17 +8,19 @@ package summon
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	"github.com/davidovich/summon/internal/testutil"
 	"github.com/gobuffalo/packr/v2/file"
 	"github.com/spf13/afero"
+
+	"github.com/davidovich/summon/internal/testutil"
 )
 
 var appFs = afero.NewOsFs()
@@ -71,11 +73,21 @@ func (d *Driver) Summon(opts ...Option) (string, error) {
 }
 
 func (d *Driver) renderTemplate(tmpl string, data map[string]interface{}) (string, error) {
-	t, err := template.New("Summon").
-		Funcs(sprig.FuncMap()).
-		Funcs(summonFuncMap(d)).
-		Parse(tmpl)
+	t := d.templateCtx
+	var err error
+	if t != nil {
+		t, err = t.Clone()
+		if err != nil {
+			return tmpl, err
+		}
+	} else {
+		t = template.New("Summon").
+			Option("missingkey=zero").
+			Funcs(sprig.TxtFuncMap()).
+			Funcs(summonFuncMap(d))
+	}
 
+	t, err = t.Parse(tmpl)
 	if err != nil {
 		return tmpl, err
 	}
@@ -83,7 +95,10 @@ func (d *Driver) renderTemplate(tmpl string, data map[string]interface{}) (strin
 	buf := &bytes.Buffer{}
 	err = t.Execute(buf, data)
 
-	return buf.String(), err
+	// The zero value for an interface is a nil interface{} which
+	// has a string representation of <no value>. Strip this out.
+	// https://github.com/golang/go/issues/24963
+	return strings.ReplaceAll(buf.String(), "<no value>", ""), err
 }
 
 func (d *Driver) resolveAlias(alias string) string {

--- a/pkg/summon/summon.go
+++ b/pkg/summon/summon.go
@@ -114,6 +114,31 @@ func summonFuncMap(d *Driver) template.FuncMap {
 		"summon": func(path string) (string, error) {
 			return d.Summon(Filename(path), Dest(os.TempDir()))
 		},
+		"arg": func(index int, missingError string) (string, error) {
+			if d.opts.args == nil {
+				return "", fmt.Errorf(missingError)
+			}
+			if index > len(d.opts.args) {
+				return "", fmt.Errorf("%s: index %v out of range, args: %s", missingError, index, d.opts.args)
+			}
+
+			retrieved := d.opts.args[index]
+			if d.opts.argsConsumed == nil {
+				d.opts.argsConsumed = map[int]struct{}{}
+			}
+			d.opts.argsConsumed[index] = struct{}{}
+			return retrieved, nil
+		},
+		"args": func() []string {
+			if d.opts.argsConsumed == nil {
+				d.opts.argsConsumed = make(map[int]struct{}, len(d.opts.args))
+			}
+			for i := range d.opts.args {
+				d.opts.argsConsumed[i] = struct{}{}
+			}
+
+			return d.opts.args
+		},
 	}
 }
 

--- a/pkg/summon/testdata/summon.config.yaml
+++ b/pkg/summon/testdata/summon.config.yaml
@@ -11,6 +11,7 @@ exec:
     bash-self-ref: ['{{ summon "hello.sh" }}']
     args: ['args:', '{{ arg 0 "" }}']
     one-arg: ['args:', '{{arg 0 "" }}']
+    all-args: ['args:', '{{ args }}']
     osArgs: ['osArgs:', '{{ .osArgs }}']
     templateref: ['{{ template "version"}}']
   docker {{ lower "INFO" }}: # template example

--- a/pkg/summon/testdata/summon.config.yaml
+++ b/pkg/summon/testdata/summon.config.yaml
@@ -10,6 +10,7 @@ exec:
     hello-bash: [ hello.sh ]
     bash-self-ref: ['{{ summon "hello.sh" }}']
     args: ['args:', '{{ .args }}']
+    one-arg: ['args:', '{{index .args 0}}']
     osArgs: ['osArgs:', '{{ .osArgs }}']
     templateref: ['{{ template "version"}}']
   docker {{ lower "INFO" }}: # template example

--- a/pkg/summon/testdata/summon.config.yaml
+++ b/pkg/summon/testdata/summon.config.yaml
@@ -9,8 +9,8 @@ exec:
   bash:
     hello-bash: [ hello.sh ]
     bash-self-ref: ['{{ summon "hello.sh" }}']
-    args: ['args:', '{{ .args }}']
-    one-arg: ['args:', '{{index .args 0}}']
+    args: ['args:', '{{ arg 0 "" }}']
+    one-arg: ['args:', '{{arg 0 "" }}']
     osArgs: ['osArgs:', '{{ .osArgs }}']
     templateref: ['{{ template "version"}}']
   docker {{ lower "INFO" }}: # template example

--- a/pkg/summon/testdata/summon.config.yaml
+++ b/pkg/summon/testdata/summon.config.yaml
@@ -3,10 +3,15 @@ aliases:
   renderableFileName: "{{.FileName}}"
   a: "subdir/a/a.txt"
 outputdir: "overridden_dir"
+templates: >-
+  {{ define "version" }}1.2.3{{ end }}
 exec:
   bash:
     hello-bash: [ hello.sh ]
     bash-self-ref: ['{{ summon "hello.sh" }}']
+    args: ['args:', '{{ .args }}']
+    osArgs: ['osArgs:', '{{ .osArgs }}']
+    templateref: ['{{ template "version"}}']
   docker {{ lower "INFO" }}: # template example
     docker:
   gobin -run:
@@ -14,3 +19,4 @@ exec:
     gohack: [github.com/rogpeppe/gohack]
   python -c:
     hello: ['print("hello from python!")']
+


### PR DESCRIPTION
user can now use {{ index .args 0 }} to get at the passed arguments

invokable arguments can be defined in multiple arrays which will
be flattened. This allows yaml anchor usages:

```
base: &base
 - a
 - b
...
exec:
  bash -c:
    echo: [*base, c, d]
```

Without flattening, this would result in:

[[a,b], c, d], but now, it renders nicely to [a, b, c, d]