### PR TITLE
adds template naming according to driver exe name

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ import (
 // located in the passed packr.Box data repository.
 // See https://github.com/gobuffalo/packr/tree/master/v2 for more information on packr Boxes.
 func Main(args []string, box *packr.Box) int {
+	summon.Name = args[0]
 	s, err := summon.New(box)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to create initial box: %v", err)

--- a/pkg/summon/driver.go
+++ b/pkg/summon/driver.go
@@ -15,6 +15,9 @@ import (
 // Summoner is the old name for Driver, use Driver instead.
 type Summoner = Driver
 
+// Name holds the name of the driver executable. By default it is "summon"
+var Name = "summon"
+
 // Driver manages functionality of summon.
 type Driver struct {
 	opts        options
@@ -54,7 +57,7 @@ func (d *Driver) Configure(opts ...Option) error {
 				return err
 			}
 			d.opts.DefaultsFrom(d.config)
-			d.templateCtx, err = template.New("Summon").
+			d.templateCtx, err = template.New(Name).
 				Option("missingkey=zero").
 				Funcs(sprig.TxtFuncMap()).
 				Funcs(summonFuncMap(d)).

--- a/pkg/summon/summon.go
+++ b/pkg/summon/summon.go
@@ -81,7 +81,7 @@ func (d *Driver) renderTemplate(tmpl string, data map[string]interface{}) (strin
 			return tmpl, err
 		}
 	} else {
-		t = template.New("Summon").
+		t = template.New(Name).
 			Option("missingkey=zero").
 			Funcs(sprig.TxtFuncMap()).
 			Funcs(summonFuncMap(d))


### PR DESCRIPTION
this gives better error messages when the exe is not named
"summon".