### PR TITLE
Simplify testing helpers

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/davidovich/summon/internal/testutil"
@@ -91,13 +90,7 @@ func TestRunCmd(t *testing.T) {
 }
 
 func TestSummonRunHelper(t *testing.T) {
-	if testutil.IsHelper() {
-		defer os.Exit(0)
-
-		call := testutil.MakeCall()
-
-		testutil.WriteCall(call)
-	}
+	testutil.TestSummonRunHelper()
 }
 
 func TestExtractUnknownArgs(t *testing.T) {

--- a/internal/testutil/testutils.go
+++ b/internal/testutil/testutils.go
@@ -145,3 +145,21 @@ func CleanHelperArgs(helperArgs []string) []string {
 
 	return args
 }
+
+// TestSummonRunHelper is a testing helper for go test subprocess mocking
+func TestSummonRunHelper() {
+	if IsHelper() {
+		defer os.Exit(0)
+
+		call := MakeCall()
+
+		WriteCall(call)
+	}
+}
+
+// TestFailRunHelper is a non zero exiting testing helper for go test subprocess mocking.
+func TestFailRunHelper() {
+	if IsHelper() {
+		os.Exit(1)
+	}
+}

--- a/pkg/summon/run_test.go
+++ b/pkg/summon/run_test.go
@@ -132,19 +132,11 @@ func TestRun(t *testing.T) {
 }
 
 func TestFailRunHelper(t *testing.T) {
-	if testutil.IsHelper() {
-		os.Exit(1)
-	}
+	testutil.TestFailRunHelper()
 }
 
 func TestSummonRunHelper(t *testing.T) {
-	if testutil.IsHelper() {
-		defer os.Exit(0)
-
-		call := testutil.MakeCall()
-
-		testutil.WriteCall(call)
-	}
+	testutil.TestSummonRunHelper()
 }
 
 func TestListInvocables(t *testing.T) {


### PR DESCRIPTION
Helper test function must be part of the package, but we can remove
duplication by placing the test helper in the testutils package.

Fixes #66