### PR TITLE
Fix help sub commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ $(HTML_COVERAGE): $(MERGED_COVERAGE)
 
 $(COVERAGE):
 	@mkdir -p $(@D)
-	go test ./... --cover -coverprofile $@ -v
+	go test ./... -timeout 30s --cover -coverprofile $@ -v
 
 .PHONY: update-coverage-badge
 update-coverage-badge: $(COVERAGE_PERCENT_FILE)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,7 @@ func CreateRootCmd(driver *summon.Driver, args []string, options summon.MainOpti
 
 	main := &mainCmd{
 		driver: driver,
+		osArgs: &args,
 	}
 
 	cmdHint := " [file to summon]"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -16,8 +16,7 @@ import (
 
 func makeRootCmd(withoutRun bool, args ...string) (*summon.Driver, *cobra.Command) {
 	s, _ := summon.New(cmdTestFS)
-	rootCmd, _ := CreateRootCmd(s, []string{"summon"}, summon.MainOptions{WithoutRunSubcmd: withoutRun})
-	rootCmd.SetArgs(args)
+	rootCmd, _ := CreateRootCmd(s, append([]string{"summon"}, args...), summon.MainOptions{WithoutRunSubcmd: withoutRun})
 	return s, rootCmd
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,26 +13,10 @@ func newRunCmd(runCmdEnabled bool, root *cobra.Command, driver summon.Configurab
 	if main.osArgs != nil {
 		osArgs = *main.osArgs
 	}
-	// calculate the extra args to pass to the referenced executable
-	// this is due to a limitation in spf13/cobra which eats
-	// all unknown args or flags making it hard to wrap other commands.
-	// We are lucky, we know the prefix order of params,
-	// extract args after the run command [summon run handle]
-	// see https://github.com/spf13/pflag/pull/160
-	// https://github.com/spf13/cobra/issues/739
-	// and https://github.com/spf13/pflag/pull/199
-	firstUnknownArgPos := 2
-	if runCmdEnabled {
-		firstUnknownArgPos = 3
-	}
-	if firstUnknownArgPos > len(osArgs) {
-		firstUnknownArgPos = len(osArgs)
-	}
-	userArgs := osArgs[firstUnknownArgPos:]
 
 	// read config for exec section
 	driver.Configure(
-		summon.Args(userArgs...),
+		summon.Args(osArgs...),
 		// TODO: JSON is set too soon because the parsing of flags might
 		// change the captured value.
 		summon.JSON(main.json),

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -87,7 +87,6 @@ func TestRunCmd(t *testing.T) {
 			if tC.args == nil {
 				tC.args = make([]string, 0)
 			}
-			cobraCmd.SetArgs(tC.args)
 			err = newRunCmd(true, cobraCmd, s, tC.main)
 			assert.NoError(t, err)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,9 +43,6 @@ type ExecDesc struct {
 // The ExecDesc target can be an ArgSliceSpec, or a CmdDesc
 type HandlesDesc map[string]ExecDesc
 
-// Handles are the normalized version of the configs HandleDesc
-type Handles map[string]*CmdSpec
-
 // Flags are the normalized FlagDesc
 type Flags map[string]*FlagSpec
 
@@ -63,24 +60,6 @@ type CmdDesc struct {
 	Help       string              `yaml:"help,omitempty"`
 	Completion string              `yaml:"completion,omitempty"`
 	Hidden     bool                `yaml:"hidden,omitempty"`
-}
-
-// CmdSpec describes a normalized command
-type CmdSpec struct {
-	// ExecEnvironment is the caller environment (docker, bash, python)
-	ExecEnvironment string
-	// Args is the command and args that get appended to the ExecEnvironment
-	Args ArgSliceSpec
-	// SubCmd sub-command of current command
-	SubCmd map[string]*CmdSpec
-	// Flags of this command
-	Flags Flags
-	// Help of this command
-	Help string
-	// Command to invoke to have a completion of this command
-	Completion string
-	// Hidden hides the command from help
-	Hidden bool
 }
 
 // FlagDesc describes a simple string flag or complex FlagSpec
@@ -102,7 +81,8 @@ type FlagSpec struct {
 	// Explicit is used to control if the flag is added automatically or not to
 	// the command-line. If Explicit is true, the flag will not be automatically
 	// added (it can be positionned in the command-line with the flagValue template
-	// function). The default is to add the rendered flag on the command line (implicit).  Note that using the {{ flagValue "my-flag" }} in a template makes the Flag Explicit.
+	// function). The default is to add the rendered flag on the command line (implicit).
+	// Note that using the {{ flagValue "my-flag" }} in a template makes the Flag Explicit.
 	Explicit bool `yaml:"explicit"`
 }
 

--- a/pkg/summon/driver.go
+++ b/pkg/summon/driver.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/spf13/cobra"
 
 	"github.com/davidovich/summon/pkg/command"
 	"github.com/davidovich/summon/pkg/config"
@@ -26,12 +27,13 @@ type Driver struct {
 	config        config.Config
 	fs            fs.FS
 	globalFlags   config.Flags
-	handles       config.Handles
+	handles       Handles
 	baseDataDir   string
 	templateCtx   *template.Template
 	execCommand   command.ExecCommandFn
 	configRead    bool
 	flagsToRender []*flagValue
+	cmdToSpec     map[*cobra.Command]*CmdSpec
 }
 
 // New creates the Driver.
@@ -39,6 +41,7 @@ func New(filesystem fs.FS, opts ...Option) (*Driver, error) {
 	d := &Driver{
 		fs:          filesystem,
 		execCommand: command.New,
+		cmdToSpec:   map[*cobra.Command]*CmdSpec{},
 	}
 
 	err := fs.WalkDir(d.fs, ".", func(path string, de fs.DirEntry, err error) error {

--- a/pkg/summon/driver.go
+++ b/pkg/summon/driver.go
@@ -27,13 +27,13 @@ type Driver struct {
 	config        config.Config
 	fs            fs.FS
 	globalFlags   config.Flags
-	handles       Handles
+	handles       handles
 	baseDataDir   string
 	templateCtx   *template.Template
 	execCommand   command.ExecCommandFn
 	configRead    bool
 	flagsToRender []*flagValue
-	cmdToSpec     map[*cobra.Command]*CmdSpec
+	cmdToSpec     map[*cobra.Command]*commandSpec
 }
 
 // New creates the Driver.
@@ -41,7 +41,7 @@ func New(filesystem fs.FS, opts ...Option) (*Driver, error) {
 	d := &Driver{
 		fs:          filesystem,
 		execCommand: command.New,
-		cmdToSpec:   map[*cobra.Command]*CmdSpec{},
+		cmdToSpec:   map[*cobra.Command]*commandSpec{},
 	}
 
 	err := fs.WalkDir(d.fs, ".", func(path string, de fs.DirEntry, err error) error {

--- a/pkg/summon/flag.go
+++ b/pkg/summon/flag.go
@@ -1,0 +1,85 @@
+package summon
+
+import (
+	"github.com/davidovich/summon/pkg/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type flagValue struct {
+	d            *Driver
+	name         string
+	effect       string
+	userValue    string
+	rendered     string
+	explicit     bool
+	initializing bool
+}
+
+func (f *flagValue) Set(s string) error {
+	if f.d.flagsToRender == nil {
+		f.d.flagsToRender = []*flagValue{}
+	}
+	var found bool
+	for _, fv := range f.d.flagsToRender {
+		if fv.name == f.name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		f.d.flagsToRender = append(f.d.flagsToRender, f)
+	}
+	f.userValue = s
+	return nil
+}
+
+// String returns the current value
+func (f *flagValue) String() string {
+	if f.initializing && f.name == "help" { // fool cobra as it is very insistant on having a help
+		return "false"
+	}
+
+	return f.userValue
+}
+
+func (f *flagValue) Type() string {
+	if f.initializing && f.name == "help" { // fool cobra as it is very insistant on having a help
+		return "bool"
+	}
+	return "string"
+}
+
+func (f *flagValue) renderTemplate() (string, error) {
+	if f.rendered != "" {
+		return f.rendered, nil
+	}
+	var err error
+	f.d.opts.data["flag"] = f.userValue
+	f.rendered, err = f.d.renderTemplate(f.effect)
+	delete(f.d.opts.data, "flag")
+	return f.rendered, err
+}
+
+func (d *Driver) AddFlags(cmd *cobra.Command, flags config.Flags, global bool) {
+	for f, flagSpec := range flags {
+		d.AddFlag(cmd, f, flagSpec, global)
+	}
+}
+
+func (d *Driver) AddFlag(cmd *cobra.Command, name string, flagSpec *config.FlagSpec, global bool) *flagValue {
+	v := &flagValue{
+		name:     name,
+		d:        d,
+		effect:   flagSpec.Effect,
+		explicit: flagSpec.Explicit,
+	}
+	var flag *pflag.Flag
+	if global {
+		flag = cmd.PersistentFlags().VarPF(v, name, flagSpec.Shorthand, flagSpec.Help)
+	} else {
+		flag = cmd.Flags().VarPF(v, name, flagSpec.Shorthand, flagSpec.Help)
+	}
+	flag.NoOptDefVal = flagSpec.Default
+	return v
+}

--- a/pkg/summon/options.go
+++ b/pkg/summon/options.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/spf13/cobra"
+
 	"github.com/davidovich/summon/pkg/command"
 	"github.com/davidovich/summon/pkg/config"
 )
@@ -25,6 +27,8 @@ type options struct {
 	tree bool
 	// reference to an exec config entry
 	ref string
+	// reference to cobra command
+	cobraCmd *cobra.Command
 	// args to exec entry
 	args []string
 	// keep track of arg indexes that were used
@@ -51,6 +55,14 @@ type Option func(*options) error
 func Args(args ...string) Option {
 	return func(opts *options) error {
 		opts.args = args
+		return nil
+	}
+}
+
+// CobraCmd captures the cobra command that is executing
+func CobraCmd(cmd *cobra.Command) Option {
+	return func(opts *options) error {
+		opts.cobraCmd = cmd
 		return nil
 	}
 }

--- a/pkg/summon/options.go
+++ b/pkg/summon/options.go
@@ -31,6 +31,8 @@ type options struct {
 	cobraCmd *cobra.Command
 	// args to exec entry
 	args []string
+	// help wanted is the position of --help or -h request
+	helpWanted helpInfo
 	// keep track of arg indexes that were used
 	argsConsumed map[int]struct{}
 	// template rendering data
@@ -45,6 +47,11 @@ type options struct {
 	dryrun bool
 	// execCommand overrides the command used to run external processes
 	execCommand command.ExecCommandFn
+}
+
+type helpInfo struct {
+	nextToHelp string
+	helpFlag   string
 }
 
 // Option allows specifying configuration settings

--- a/pkg/summon/run_test.go
+++ b/pkg/summon/run_test.go
@@ -244,10 +244,10 @@ exec:
 
 	assert.Equal(t,
 		[]string{"pwd:", "{{ env \"PWD\" | base }}"},
-		FlattenStrings(handles["echo-pwd"].Args...))
+		FlattenStrings(handles["echo-pwd"].args...))
 	assert.Equal(t,
 		[]string{"manifests/{{ arg 0 }}", `{{ flag "config-root" }}`},
-		FlattenStrings(handles["manifest"].Args))
+		FlattenStrings(handles["manifest"].args))
 
 	assert.Contains(t, flags, "config-root")
 }
@@ -474,7 +474,7 @@ func (ft flagTest) run(t *testing.T) {
 		}},
 	}
 	d.configRead = true
-	d.cmdToSpec = map[*cobra.Command]*CmdSpec{}
+	d.cmdToSpec = map[*cobra.Command]*commandSpec{}
 	d.Configure(ExecCmd(func(cmd string, args ...string) *command.Cmd {
 		return &command.Cmd{
 			Cmd: &exec.Cmd{},

--- a/pkg/summon/summon.go
+++ b/pkg/summon/summon.go
@@ -164,8 +164,10 @@ func summonFuncMap(d *Driver) template.FuncMap {
 				templateCtx: d.templateCtx,
 				execCommand: d.execCommand,
 				configRead:  d.configRead,
+				cmdToSpec:   d.cmdToSpec,
 			}
 			driverCopy.opts.argsConsumed = map[int]struct{}{}
+			driverCopy.opts.cobraCmd = nil
 			b := &strings.Builder{}
 			err := driverCopy.Run(Ref(args[0]), Args(args[1:]...), Out(b))
 

--- a/pkg/summon/testdata/summon.config.yaml
+++ b/pkg/summon/testdata/summon.config.yaml
@@ -22,7 +22,7 @@ exec:
         subCmd:
           subcmd:
             help: "override subcmd help"
-            args: [hello.sh subcmd]
+            args: [hello.sh, subcmd]
 
     docker {{ lower "INFO" }}: # template example
       docker: []


### PR DESCRIPTION
Cobra is very aggressive in wanting to manage the `--help` flag. This limits the possibility to pass `--help` to a proxied program. 

This PR implements a mechanism to remove help from cobra's view and add it only we know it will do the right thing (on cobra command tree entries). If cobra does not manage help, it can be correctly forwarded to proxied commands.

closes #18