### PR TITLE
Support joining params in one line

### DIFF
--- a/examples/cmd-proxy/assets/summon.config.yaml
+++ b/examples/cmd-proxy/assets/summon.config.yaml
@@ -52,10 +52,11 @@ exec:
         # tk uses the posener/complete library. Fake a completion call by
         # setting the COMP_LINE environment var.
         completion: '{{ run "bash-c" (printf "COMP_LINE=''%s'' tk" (join " " args)) }}'
+        join: true
 
       manifest [env]:
         help: 'render kubernetes manifests in build dir'
-        args: ['echo manifests/{{arg 0 "manifest"}} {{flagValue "config-root" }}']
+        args: ['echo manifests/{{arg 0 "manifest"}} {{- flagValue "config-root" -}}']
         completion: '{{ run "fake-make" "a-env\nb-env\n" }}'
 
       build:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,7 @@ type CmdDesc struct {
 	Help       string              `yaml:"help,omitempty"`
 	Completion string              `yaml:"completion,omitempty"`
 	Hidden     bool                `yaml:"hidden,omitempty"`
+	Inline     *bool               `yaml:"join,omitempty"`
 }
 
 // FlagDesc describes a simple string flag or complex FlagSpec

--- a/pkg/summon/run_test.go
+++ b/pkg/summon/run_test.go
@@ -149,6 +149,16 @@ func TestRun(t *testing.T) {
 			name: "with-dry-run",
 			args: []string{"hello-bash", "-n"},
 		},
+		{
+			name:   "join-arguments",
+			args:   []string{"hello-join"},
+			expect: []string{"python -c print(\" these params will be joined \")"},
+		},
+		{
+			name:   "join-then-dont-on-subarguments",
+			args:   []string{"hello-join", "non-inlined"},
+			expect: []string{"python -c print(\"hello\") # these are separate args -"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/summon/testdata/summon.config.yaml
+++ b/pkg/summon/testdata/summon.config.yaml
@@ -30,3 +30,12 @@ exec:
       gohack: [github.com/rogpeppe/gohack@latest]
     python -c:
       hello: ['print("hello from python!")']
+      hello-join:
+        args: ['print("', 'these', 'params', 'will', 'be', 'joined', '")']
+        join: true
+        subCmd:
+          non-inlined:
+            args: ['print("hello")', '#', 'these', 'are', 'separate', 'args', '-']
+            join: false
+
+


### PR DESCRIPTION
can be usefull for exec environments like `bash -c` where the parameter
is one bash invocation.