### PR TITLE
use string pointer to delay evaluation of value

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -169,7 +169,7 @@ func (m *mainCmd) run() error {
 		summon.All(m.copyAll),
 		summon.Dest(m.dest),
 		summon.Filename(m.filename),
-		summon.JSON(m.json),
+		summon.JSON(&m.json),
 		summon.Raw(m.raw),
 	)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -17,9 +17,7 @@ func newRunCmd(runCmdEnabled bool, root *cobra.Command, driver summon.Configurab
 	// read config for exec section
 	driver.Configure(
 		summon.Args(osArgs...),
-		// TODO: JSON is set too soon because the parsing of flags might
-		// change the captured value.
-		summon.JSON(main.json),
+		summon.JSON(&main.json),
 	)
 
 	return driver.ConstructCommandTree(root, runCmdEnabled)

--- a/internal/scaffold/create.go
+++ b/internal/scaffold/create.go
@@ -32,10 +32,11 @@ func Create(destDir, modName, summonerName string, force bool) error {
 		}
 	}
 
+	json := fmt.Sprintf(scaffoldParams, modName, summonerName)
 	_, err = s.Summon(
 		summon.All(true),
 		summon.Filename("templates/scaffold"),
-		summon.JSON(fmt.Sprintf(scaffoldParams, modName, summonerName)),
+		summon.JSON(&json),
 		summon.Dest(destDir),
 	)
 

--- a/pkg/summon/options.go
+++ b/pkg/summon/options.go
@@ -2,6 +2,7 @@ package summon
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -150,15 +151,18 @@ func ShowTree(tree bool) Option {
 }
 
 // JSON configures the dictionary to use to render a templated asset.
-func JSON(j string) Option {
+func JSON(j *string) Option {
 	return func(opts *options) error {
-		if j == "" {
+		if j == nil {
+			return fmt.Errorf("json string config cannot be nil")
+		}
+		if *j == "" {
 			opts.data = map[string]interface{}{}
 			return nil
 		}
 
 		var data map[string]interface{}
-		err := json.Unmarshal([]byte(j), &data)
+		err := json.Unmarshal([]byte(*j), &data)
 
 		if err != nil {
 			return err

--- a/pkg/summon/options_test.go
+++ b/pkg/summon/options_test.go
@@ -39,4 +39,20 @@ func TestOptions(t *testing.T) {
 		configure(&config, Dest(""))
 		assert.Equal(t, "already-set", config.destination)
 	})
+
+	t.Run("json", func(t *testing.T) {
+		o := &options{}
+		err := JSON(nil)(o)
+		assert.Error(t, err)
+
+		str := ""
+		err = JSON(&str)(o)
+		assert.NoError(t, err)
+		assert.NotNil(t, o.data)
+
+		// invalid json
+		str = `f{k`
+		err = JSON(&str)(o)
+		assert.Error(t, err)
+	})
 }

--- a/pkg/summon/summon_test.go
+++ b/pkg/summon/summon_test.go
@@ -76,7 +76,8 @@ func TestSubfolderHierarchy(t *testing.T) {
 	a := assert.New(t)
 
 	// create a summoner to summon a complete hierarchy
-	s, err := New(summonTestFS, Filename("subdir/"), Dest("o"), JSON(`{"TemplatedName":"b", "Content":"b content"}`))
+	jsonInput := `{"TemplatedName":"b", "Content":"b content"}`
+	s, err := New(summonTestFS, Filename("subdir/"), Dest("o"), JSON(&jsonInput))
 	a.NoError(err)
 
 	path, err := s.Summon()
@@ -164,7 +165,7 @@ func TestSummonScenarios(t *testing.T) {
 
 	for _, tC := range testCases[len(testCases)-1:] {
 		t.Run(tC.desc, func(t *testing.T) {
-			args := []Option{Filename(tC.filename), JSON(tC.json), Dest(tC.dest), Raw(tC.raw)}
+			args := []Option{Filename(tC.filename), JSON(&tC.json), Dest(tC.dest), Raw(tC.raw)}
 			output := &bytes.Buffer{}
 			if tC.dest == "-" {
 				args = append(args, Out(output))


### PR DESCRIPTION
configuration happens after flag parsing in cobra, using a pointer
allows the value to be set in time.