### PR TITLE
Last minute fixes

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -18,7 +18,7 @@ type listCmdOpts struct {
 	cmd      *cobra.Command
 }
 
-func newListCmd(asOption bool, root *cobra.Command, driver summon.ConfigurableLister, main *mainCmd) *cobra.Command {
+func newListCmd(asOption bool, root *cobra.Command, driver summon.ConfigurableLister, main *mainCmd) {
 	listCmd := &listCmdOpts{
 		driver: driver,
 	}
@@ -42,8 +42,6 @@ func newListCmd(asOption bool, root *cobra.Command, driver summon.ConfigurableLi
 
 	listCmd.out = root.OutOrStdout()
 	root.Flags().BoolVar(&listCmd.tree, "tree", false, "Print pretty tree of data")
-
-	return root
 }
 
 func (l *listCmdOpts) run() error {

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -38,14 +38,14 @@ func TestListCmd(t *testing.T) {
 			s, _ := summon.New(cmdTestFS)
 
 			rootCmd := &cobra.Command{Use: "root", Run: func(cmd *cobra.Command, args []string) {}}
-			newRoot := newListCmd(false, rootCmd, s, &mainCmd{})
+			newListCmd(false, rootCmd, s, &mainCmd{})
 			if tt.args == nil {
 				tt.args = make([]string, 0)
 			}
 			rootCmd.SetArgs(tt.args)
 
 			b := &bytes.Buffer{}
-			newRoot.SetOut(b)
+			rootCmd.SetOut(b)
 			rootCmd.Execute()
 
 			assert.Contains(t, b.String(), tt.expected)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -42,6 +42,12 @@ func TestRunCmd(t *testing.T) {
 			wantError: true,
 		},
 		{
+			desc:      "help-flag-on-root-works",
+			args:      []string{"--help"},
+			wantError: false,
+			noCalls:   true,
+		},
+		{
 			desc: "sub-param-passed",
 			args: []string{"run", "echo", "--unknown-arg", "last", "params"},
 			main: &mainCmd{

--- a/internal/scaffold/templates/scaffold/Makefile
+++ b/internal/scaffold/templates/scaffold/Makefile
@@ -6,6 +6,8 @@ all: bin/$(SUMMONER_NAME)
 
 bin/$(SUMMONER_NAME): $(SUMMONER_NAME)/$(SUMMONER_NAME).go $(ASSETS)
 	go build -o $@ $<
+	@echo testing created $(SUMMONER_NAME)
+	go run $< --help
 
 .PHONY: clean
 clean:

--- a/internal/scaffold/templates/scaffold/{{.SummonerName}}/assets/summon.config.yaml
+++ b/internal/scaffold/templates/scaffold/{{.SummonerName}}/assets/summon.config.yaml
@@ -3,4 +3,7 @@
 version: 1
 aliases: {}
 outputdir: ".summoned"
-exec: {}
+hideAssetsInHelp: false
+exec:
+  flags: {}
+  environments: {}

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func Main(args []string, fs embed.FS, opts ...option) int {
 	summon.Name = args[0]
 	s, err := summon.New(fs)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to create initial filesystem: %v", err)
+		fmt.Fprintf(os.Stderr, "unable to create initial filesystem: %v\n", err)
 		return 1
 	}
 
@@ -59,7 +59,7 @@ func Main(args []string, fs embed.FS, opts ...option) int {
 
 	rootCmd, err := cmd.CreateRootCmd(s, os.Args, *options)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "could not create command tree: %v", err)
+		fmt.Fprintf(os.Stderr, "could not create command tree: %v\n", err)
 		return 1
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,12 +20,12 @@ type Alias map[string]string
 
 // Config is the summon config
 type Config struct {
-	Version         int
-	Aliases         Alias       `yaml:"aliases"`
-	OutputDir       string      `yaml:"outputdir"`
-	TemplateContext string      `yaml:"templates"`
-	Exec            ExecContext `yaml:"exec"`
-	Help            string      `yaml:"help"`
+	Version          int
+	Aliases          Alias       `yaml:"aliases"`
+	OutputDir        string      `yaml:"outputdir"`
+	TemplateContext  string      `yaml:"templates"`
+	Exec             ExecContext `yaml:"exec"`
+	HideAssetsInHelp bool        `yaml:"hideAssetsInHelp"`
 }
 
 // ExecContext houses execution environments and global flags
@@ -54,13 +54,21 @@ type ArgSliceSpec []interface{}
 // Its SubCmd is an ExecDesc so it can be an ArgsSliceSpec or a CmdSpec
 // Its Flags can be a one line string flag or a FlagSpec
 type CmdDesc struct {
-	Args       ArgSliceSpec        `yaml:"args"`
-	SubCmd     map[string]ExecDesc `yaml:"subCmd,omitempty"`
-	Flags      map[string]FlagDesc `yaml:"flags,omitempty"`
-	Help       string              `yaml:"help,omitempty"`
-	Completion string              `yaml:"completion,omitempty"`
-	Hidden     bool                `yaml:"hidden,omitempty"`
-	Inline     *bool               `yaml:"join,omitempty"`
+	// Args contain the args that get appended to the ExecEnvironment
+	Args ArgSliceSpec `yaml:"args"`
+	// SubCmd describes a sub-command of current command
+	SubCmd map[string]ExecDesc `yaml:"subCmd,omitempty"`
+	// Flags of this command
+	Flags map[string]FlagDesc `yaml:"flags,omitempty"`
+	// Help line of this command
+	Help string `yaml:"help,omitempty"`
+	// Completion holds the command to invoke to have a completion of
+	// this command. It can contain templates.
+	Completion string `yaml:"completion,omitempty"`
+	// Hidden hides the command from help
+	Hidden bool `yaml:"hidden,omitempty"`
+	// Join joins arguments to form one argument of one line of text
+	Join *bool `yaml:"join,omitempty"`
 }
 
 // FlagDesc describes a simple string flag or complex FlagSpec

--- a/pkg/summon/driver.go
+++ b/pkg/summon/driver.go
@@ -66,9 +66,8 @@ func New(filesystem fs.FS, opts ...Option) (*Driver, error) {
 	return d, nil
 }
 
-func (d Driver) OutputDir() string {
-	return d.config.OutputDir
-}
+func (d Driver) OutputDir() string      { return d.config.OutputDir }
+func (d Driver) HideAssetsInHelp() bool { return d.config.HideAssetsInHelp }
 
 // Configure is used to extract options and customize the summon.Driver.
 func (d *Driver) Configure(opts ...Option) error {

--- a/pkg/summon/run.go
+++ b/pkg/summon/run.go
@@ -202,8 +202,8 @@ func normalizeExecDesc(argsDesc interface{}, invoker string) (*commandSpec, erro
 		c.help = descType.Help
 		c.completion = descType.Completion
 		c.hidden = descType.Hidden
-		if descType.Inline != nil {
-			c.join = descType.Inline
+		if descType.Join != nil {
+			c.join = descType.Join
 		}
 		if descType.SubCmd != nil {
 			c.subCmd = make(map[string]*commandSpec)

--- a/pkg/summon/run.go
+++ b/pkg/summon/run.go
@@ -433,11 +433,13 @@ func (d *Driver) setupArgs(root *cobra.Command) {
 		managedHelp = append(managedHelp, a)
 	}
 
-	// if help is requested on a managed command, let cobra manage the help flag
+	// if help is requested on:
+	//   * a managed command that has a help line
+	//   * on the root (no parameters)
 	var ownHelp bool
 	if helpFlag != "" {
 		cmd, _, _ := root.Root().Find(allArgs[:helpPos])
-		if cmd != root && cmd.Short != "" {
+		if cmd != root && cmd.Short != "" || len(managedHelp) == 0 {
 			ownHelp = true
 		}
 	}

--- a/pkg/summon/run_test.go
+++ b/pkg/summon/run_test.go
@@ -54,10 +54,12 @@ func TestRun(t *testing.T) {
 		{
 			name:   "self-reference-run", // bash
 			helper: "TestSubCommandTemplateRunCall",
-			cmd:    []string{"run-example"},
+			cmd:    []string{"run-example", "--help"},
 			expect: []string{
-				"bash hello.sh",          // run first call (returns "hello from subcmd")
-				"bash hello from subcmd", // actual run-example call with args
+				// run first call (returns "hello from subcmd")
+				// should not have help active
+				"bash hello.sh",
+				"bash hello from subcmd --help", // actual run-example call with args
 			},
 			wantErr: false,
 		},

--- a/pkg/summon/summon.go
+++ b/pkg/summon/summon.go
@@ -168,6 +168,7 @@ func summonFuncMap(d *Driver) template.FuncMap {
 			}
 			driverCopy.opts.argsConsumed = map[int]struct{}{}
 			driverCopy.opts.cobraCmd = nil
+			driverCopy.opts.helpWanted.helpFlag = ""
 			b := &strings.Builder{}
 			err := driverCopy.Run(Ref(args[0]), Args(args[1:]...), Out(b))
 


### PR DESCRIPTION
This PR brings final touches after experimenting with a real implementation.

Allows disabling summonables as commands in config

The effect of this is that they do not show up in help, but are shown in
completions.

Fix bug where summonable commands were added to the wrong sub-command
(list command). This was missed because there were no tests with run
and without runl subcommands. This is addressed.

Ensure that completion still works if summonables are not commands.

Hides the help subcommand because we have a --help flag.

Fixes root_tests that were written in a way that they were gathering
state in the root creation helper (was called at test table creation
time).
