### PR TITLE
Allow fully templated commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.17
-    environment:
-      GO111MODULE=on
+      - image: cimg/go:1.18
     steps:
 
       - checkout

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: Build and Test
       run: make

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ HAS_GOCOVERUTIL			:= $(shell command -v gocoverutil)
 export GO111MODULE := on
 
 SCAFFOLD_BIN := bin/scaffold
-SRCS = $(shell GO111MODULE=on go list -f '{{ $$dir := .Dir}}{{range .GoFiles}}{{ printf "%s/%s\n" $$dir . }}{{end}}' $(1)/... github.com/davidovich/summon/...)
+SRCS = $(shell go list -buildvcs=false -f '{{ $$dir := .Dir}}{{range .GoFiles}}{{ printf "%s/%s\n" $$dir . }}{{end}}' $(1)/... github.com/davidovich/summon/...)
 COVERAGE_PERCENT_FILE := $(CURDIR)/build/coverage-percent.txt
 
 DOC_REPO_NAME := davidovich.github.io
@@ -60,7 +60,7 @@ $(HTML_COVERAGE): $(MERGED_COVERAGE)
 
 $(COVERAGE):
 	@mkdir -p $(@D)
-	go test ./... -timeout 30s --cover -coverprofile $@ -v
+	go test -buildvcs=false ./... -timeout 30s --cover -coverprofile $@ -v
 
 .PHONY: update-coverage-badge
 update-coverage-badge: $(COVERAGE_PERCENT_FILE)

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,9 @@
 SHELL=/bin/bash
 
-HAS_GOCOVERUTIL			:= $(shell command -v gocoverutil)
-
 export GO111MODULE := on
 
 SCAFFOLD_BIN := bin/scaffold
 SRCS = $(shell go list -buildvcs=false -f '{{ $$dir := .Dir}}{{range .GoFiles}}{{ printf "%s/%s\n" $$dir . }}{{end}}' $(1)/... github.com/davidovich/summon/...)
-COVERAGE_PERCENT_FILE := $(CURDIR)/build/coverage-percent.txt
 
 DOC_REPO_NAME := davidovich.github.io
 DOC_REPO := git@github.com:davidovich/$(DOC_REPO_NAME).git
@@ -30,9 +27,9 @@ bin/cmd-proxy: $(call SRCS,github.com/davidovich/summon/examples/cmd-proxy) $(sh
 $(SCAFFOLD_BIN): $(ASSETS) $(call SRCS,github.com/davidovich/summon/scaffold)
 	go build -o $@ $(@F)/$(@F).go
 
-COVERAGE := build/coverage/report/summon
-MERGED_COVERAGE := build/coverage/report/cover.merged.out
-HTML_COVERAGE := build/coverage/html/index.html
+COVERAGE := build/coverage/coverage.out
+COVERAGE_PERCENT_FILE := build/coverage/percent.txt
+HTML_COVERAGE := build/coverage/index.html
 
 .PHONY: test
 test: clean-coverage output-coverage
@@ -42,25 +39,19 @@ clean-coverage:
 	rm -f $(COVERAGE)
 
 .PHONY: output-coverage
-output-coverage: $(MERGED_COVERAGE) $(HTML_COVERAGE)
+output-coverage: $(COVERAGE) $(HTML_COVERAGE)
 	go tool cover -func=$<
 
-$(COVERAGE_PERCENT_FILE): $(MERGED_COVERAGE)
+$(COVERAGE_PERCENT_FILE): $(COVERAGE)
 	go tool cover -func=$< | sed -n 's/total:[[:space:]]*(statements)[[:space:]]*\([0-9.]*\)%/\1/gw $@'
 
-$(MERGED_COVERAGE): $(COVERAGE)
-ifndef HAS_GOCOVERUTIL
-	go install github.com/AlekSi/gocoverutil@v0.2.0
-endif
-	gocoverutil -coverprofile=$@ merge $^
-
-$(HTML_COVERAGE): $(MERGED_COVERAGE)
+$(HTML_COVERAGE): $(COVERAGE)
 	@mkdir -p $(@D)
 	go tool cover -html=$< -o $@
 
 $(COVERAGE):
 	@mkdir -p $(@D)
-	go test -buildvcs=false ./... -timeout 30s --cover -coverprofile $@ -v
+	go test -buildvcs=false ./... -timeout 30s --coverpkg=./... -coverprofile $@ -v
 
 .PHONY: update-coverage-badge
 update-coverage-badge: $(COVERAGE_PERCENT_FILE)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -145,19 +145,19 @@ func Test_RootCmdWithRunnables(t *testing.T) {
 	tests := []struct {
 		name         string
 		args         []string
-		expectedCall string
+		expectedCall []string
 		wantErr      bool
 	}{
 		{
 			name:         "call echo",
 			args:         []string{"echo"},
-			expectedCall: "bash echo hello",
+			expectedCall: []string{"bash", "echo", "hello "},
 			wantErr:      false,
 		},
 		{
 			name:         "call hello-bash",
 			args:         []string{"hello-bash"},
-			expectedCall: "bash hello.sh",
+			expectedCall: []string{"bash", "hello.sh"},
 			wantErr:      false,
 		},
 	}
@@ -177,7 +177,7 @@ func Test_RootCmdWithRunnables(t *testing.T) {
 
 			c, err := testutil.GetCalls(stderr)
 			assert.Nil(t, err)
-			assert.Contains(t, c.Calls[0].Args, tt.expectedCall)
+			assert.Equal(t, c.Calls[0].Args, tt.expectedCall)
 		})
 	}
 }

--- a/cmd/testdata/summon.config.yaml
+++ b/cmd/testdata/summon.config.yaml
@@ -5,22 +5,21 @@ aliases:
 outputdir: "overridden_dir"
 exec:
   environments:
-    bash:
-      echo:
-        - echo
-        - hello {{ .Name -}}
-      hello-bash: [hello.sh]
+    echo:
+      - bash
+      - echo
+      - hello {{ .Name -}}
+    hello-bash: [bash, hello.sh]
 
-      tk:
-        args: [tk]
-        completion: '{{ run "fake-make" "a\nb\n" }}'
+    tk:
+      args: [tk]
+      completion: '{{ run "fake-make" "a\nb\n" }}'
 
-    bash --norc --noprofile -c:
-      fake-make:
-        args: ['echo -e "{{- args | join " " -}}"']
-        help: simulate make call echo params
+    fake-make:
+      cmd: [bash, --norc, --noprofile, -c]
+      args: ['echo -e "{{- args | join " " -}}"']
+      help: simulate make call echo params
 
-    go run:
-      gohack: [github.com/rogpeppe/gohack@latest]
-    python -c:
-      hello: [print("hello from python!")]
+    gohack: [go, run, github.com/rogpeppe/gohack@latest]
+
+    hello: [python, -c, print("hello from python!")]

--- a/cmd/testdata/summon.config.yaml
+++ b/cmd/testdata/summon.config.yaml
@@ -4,7 +4,7 @@ aliases:
   a: "subdir/a/a.txt"
 outputdir: "overridden_dir"
 exec:
-  environments:
+  handles:
     echo:
       - bash
       - echo

--- a/cmd/testdata/summon.config.yaml
+++ b/cmd/testdata/summon.config.yaml
@@ -8,7 +8,7 @@ exec:
     echo:
       - bash
       - echo
-      - hello {{ .Name -}}
+      - "'hello {{ .Name -}}'"
     hello-bash: [bash, hello.sh]
 
     tk:
@@ -17,7 +17,7 @@ exec:
 
     fake-make:
       cmd: [bash, --norc, --noprofile, -c]
-      args: ['echo -e "{{- args | join " " -}}"']
+      args: ['"echo -e {{ args | join " " -}}"']
       help: simulate make call echo params
 
     gohack: [go, run, github.com/rogpeppe/gohack@latest]

--- a/examples/cmd-proxy/assets/summon.config.yaml
+++ b/examples/cmd-proxy/assets/summon.config.yaml
@@ -14,8 +14,16 @@ exec:
     config-root: 'CONFIG_ROOT={{.flag}}'
 
   handles:
-    test:
-      cmd: ['{{ printf "%s" (env "inContainer") }}']
+    test: ['python3', '-c', "'print(\"hello from python\")'"]
+    testContainer:
+      cmd:
+      - |-
+        {{ if not (env "inContainer") }}
+        echo docker run -v \"{{ env "PWD" }}\"
+        -w \"a-dir\"
+        alpine
+        {{ end }}
+
       args: [*string, 'b', 'c']
 
 

--- a/examples/cmd-proxy/assets/summon.config.yaml
+++ b/examples/cmd-proxy/assets/summon.config.yaml
@@ -13,7 +13,7 @@ exec:
   flags:
     config-root: 'CONFIG_ROOT={{.flag}}'
 
-  environments:
+  handles:
     test:
       cmd: ['{{ printf "%s" (env "inContainer") }}']
       args: [*string, 'b', 'c']

--- a/examples/cmd-proxy/assets/summon.config.yaml
+++ b/examples/cmd-proxy/assets/summon.config.yaml
@@ -5,87 +5,94 @@ aliases: {}
 outputdir: ".summoned" # where summoned files are placed
 hideAssetsInHelp: true # should the assets be shown in the help ?
 
-.base: &baseargs
-- echo
+.base: &baseargs [ echo ]
+
+.aString: &string '{{ if env "echo" }}echo{{ end }}'
 
 exec:
   flags:
     config-root: 'CONFIG_ROOT={{.flag}}'
 
   environments:
-    go run:
-      gohack [command]:
-        args: &rog [github.com/rogpeppe/gohack@latest]
-        completion: '{{ printf "get\nundo\nstatus\nhelp" }}'
-        subCmd:
-          get [module]:
-            args: [*rog, get,'{{ flagValue "vcs" }}']
-            flags:
-              vcs: { effect: '{{.flag}}', default: '-vcs'}
-          undo: [*rog, undo]
-          status: [*rog, status]
-          help [command]:
-            args: [*rog, help]
-            completion: '{{ printf "get\nundo\nstatus" }}'
+    test:
+      cmd: ['{{ printf "%s" (env "inContainer") }}']
+      args: [*string, 'b', 'c']
 
 
-    bash --norc --noprofile -c:
-      fake-make:
-        args: ['echo -e "{{- args | join " " -}}"']
-        help: simulate make call echo param
-        hidden: true
-      bash-c:
-        hidden: true
+    gohack [command]:
+      cmd: &gorun [go, run]
+      args: &rog [github.com/rogpeppe/gohack@latest]
+      completion: '{{ printf "get\nundo\nstatus\nhelp" }}'
+      subCmd:
+        get [module]:
+          args: [*rog, get,'{{ flagValue "vcs" }}']
+          flags:
+            vcs: { effect: '{{.flag}}', default: '-vcs'}
+        undo: [*rog, undo]
+        status: [*rog, status]
+        help [command]:
+          args: [*rog, help]
+          completion: '{{ printf "get\nundo\nstatus" }}'
+
+    fake-make:
+      cmd: &bash-c [bash, --norc, --noprofile, -c]
+      args: ['echo -e "{{- args | join " " -}}"']
+      help: simulate make call echo param
+      hidden: true
+    bash-c:
+      cmd: *bash-c
+      hidden: true
 
     kubectl: # kubectl 0.23.1 uses the newer cobra completion which will allow delegating completions
-      kubectl:
-        completion: '{{ (split ":" (run "bash-c" (printf "kubectl __complete %s ''%s''" (join " " (rest (initial args))) (last args))))._0 }}'
-        help: call kubectl directly
+      cmd: [kubectl]
+      completion: '{{ (split ":" (run "bash-c" (printf "kubectl __complete %s ''%s''" (join " " (rest (initial args))) (last args))))._0 }}'
+      help: call kubectl directly
 
-    bash:
-      hello-bash: ['{{ summon "hello.sh" }}']
+    hello-bash: [bash, '{{ summon "hello.sh" }}']
 
-    bash -c:
-      tk:
-        args: [tk]
-        help: call tanka directly
-        # tk uses the posener/complete library. Fake a completion call by
-        # setting the COMP_LINE environment var.
-        completion: '{{ run "bash-c" (printf "COMP_LINE=''%s'' tk" (join " " args)) }}'
-        join: true
+    tk:
+      cmd: [bash, -c]
+      args: [tk]
+      help: call tanka directly
+      # tk uses the posener/complete library. Fake a completion call by
+      # setting the COMP_LINE environment var.
+      completion: '{{ run "bash-c" (printf "COMP_LINE=''%s'' tk" (join " " args)) }}'
+      join: true
 
-      manifest [env]:
-        help: 'render kubernetes manifests in build dir'
-        args: ['echo manifests/{{arg 0 "manifest"}} {{- flagValue "config-root" -}}']
-        completion: '{{ run "fake-make" "a-env\nb-env\n" }}'
+    manifest [env]:
+      cmd: [bash, -c]
+      help: 'render kubernetes manifests in build dir'
+      args: ['echo manifests/{{arg 0 "manifest"}} {{- flagValue "config-root" -}}']
+      completion: '{{ run "fake-make" "a-env\nb-env\n" }}'
 
-      build:
-        help: 'build components'
-        args: ['echo build/{{arg 0}} {{ flagValue "config-root" }}']
-        subCmd:
-          image [path to Dockerfile]:
-            args: ['echo would build build/image/{{- arg 0 "build image" -}}']
-            help: "build images in this repo"
-            completion: '{{ run "fake-make" "a-image\nb-image" }}'
+    build:
+      cmd: [bash, -c]
+      help: 'build components'
+      args: ['echo build/{{arg 0}} {{ flagValue "config-root" }}']
+      subCmd:
+        image [path to Dockerfile]:
+          args: ['echo would build build/image/{{- arg 0 "build image" -}}']
+          help: "build images in this repo"
+          completion: '{{ run "fake-make" "a-image\nb-image" }}'
 
-          gitlab-ci.yaml:
-            flags:
-              one-pipeline:
-                effect: '{{ if eq .flag "true" }}PARENT_CHILD=0{{ else }}PARENT_CHILD=1{{ end }}'
-                default: "true"
-                help: should the pipeline be added directly or with a parent-child style
-            args: ['echo would run {{ flagValue "one-pipeline" }}']
-            help: "Initialize or merge gitlab-ci.yaml"
-            subCmd:
-              sub:
-                args: ['echo gitlab-ci.yaml sub {{ args }}']
+        gitlab-ci.yaml:
+          flags:
+            one-pipeline:
+              effect: '{{ if eq .flag "true" }}PARENT_CHILD=0{{ else }}PARENT_CHILD=1{{ end }}'
+              default: "true"
+              help: should the pipeline be added directly or with a parent-child style
+          args: ['echo would run {{ flagValue "one-pipeline" }}']
+          help: "Initialize or merge gitlab-ci.yaml"
+          subCmd:
+            sub:
+              args: ['echo gitlab-ci.yaml sub {{ args }}']
 
-    docker run -v {{ env "PWD" }}:/mounted-app alpine:
-      list:
-        args: [ls, /mounted-app]
-        help: list files of mount a seen from inside container
+    list:
+      cmd: [docker, run, -v, '{{ env "PWD" }}:/mounted-app', alpine]
+      args: [ls, /mounted-app]
+      help: list files of mount a seen from inside container
 
-    docker run -ti -v {{ env "PWD"}}:/workdir -w /workdir alpine:
-      echo-alpine:
-        args: [echo]
-        help: use alpine to echo a string
+    echo-alpine:
+      cmd: [docker, run, -ti, -v, '{{ env "PWD"}}:/workdir', -w, /workdir, alpine]
+      args: [echo]
+      help: use alpine to echo a string

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/huandu/xstrings v1.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/davidovich/summon
 
-go 1.17
+go 1.18
 
 require (
 	github.com/DiSiqueira/GoTree v1.0.1-0.20190529205929-3e23dcd4532b
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/lithammer/dedent v1.1.0
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,6 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/scaffold/templates/scaffold/{{.SummonerName}}/assets/summon.config.yaml
+++ b/internal/scaffold/templates/scaffold/{{.SummonerName}}/assets/summon.config.yaml
@@ -6,4 +6,4 @@ outputdir: ".summoned"
 hideAssetsInHelp: false
 exec:
   flags: {}
-  environments: {}
+  handles: {}

--- a/internal/testutil/testutils.go
+++ b/internal/testutil/testutils.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/davidovich/summon/pkg/command"
 	"github.com/spf13/afero"
@@ -31,7 +30,7 @@ func ReplaceFs() func() {
 
 //Call is a recording of a fake call
 type Call struct {
-	Args string
+	Args []string
 	Env  []string
 	Out  string
 }
@@ -79,10 +78,7 @@ func FakeExecCommand(testToCall string, stdout, stderr *bytes.Buffer) func(strin
 
 // IsHelper returns true if a process helper is wanted
 func IsHelper() bool {
-	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
-		return false
-	}
-	return true
+	return os.Getenv("GO_WANT_HELPER_PROCESS") == "1"
 }
 
 func startCall(out io.Writer) {
@@ -96,7 +92,7 @@ func willAppendCall(out io.Writer) {
 // MakeCall prepares a call structure
 func MakeCall() Call {
 	return Call{
-		Args: strings.Join(CleanHelperArgs(os.Args), " "),
+		Args: CleanHelperArgs(os.Args),
 		Env:  os.Environ(),
 	}
 }

--- a/internal/testutil/testutils_test.go
+++ b/internal/testutil/testutils_test.go
@@ -12,11 +12,11 @@ func TestUnMarshallCall(t *testing.T) {
 	out := &bytes.Buffer{}
 
 	call1 := Call{
-		Args: "a b c",
+		Args: []string{"a", "b", "c"},
 		Env:  []string{"a=b"},
 	}
 	call2 := Call{
-		Args: "a b c",
+		Args: []string{"a", "b", "c"},
 		Env:  []string{"a=b"},
 	}
 
@@ -36,8 +36,8 @@ func TestUnMarshallCall(t *testing.T) {
 
 func TestMarshallCalls(t *testing.T) {
 	c := Calls{Calls: []Call{
-		Call{
-			Args: "a b c",
+		{
+			Args: []string{"a", "b", "c"},
 			Env:  []string{"a=b"},
 			Out:  "output",
 		},
@@ -46,5 +46,5 @@ func TestMarshallCalls(t *testing.T) {
 	b, err := json.Marshal(c)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "{\"Calls\":[{\"Args\":\"a b c\",\"Env\":[\"a=b\"],\"Out\":\"output\"}]}", string(b))
+	assert.Equal(t, "{\"Calls\":[{\"Args\":[\"a\",\"b\",\"c\"],\"Env\":[\"a=b\"],\"Out\":\"output\"}]}", string(b))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,18 +30,15 @@ type Config struct {
 
 // ExecContext houses execution environments and global flags
 type ExecContext struct {
-	ExecEnv     map[string]HandlesDesc `yaml:"environments"`
-	GlobalFlags map[string]FlagDesc    `yaml:"flags"`
+	ExecEnv     map[string]ExecDesc `yaml:"environments"`
+	GlobalFlags map[string]FlagDesc `yaml:"flags"`
 }
 
-// ExecDesc allows unmarshaling complex subtype
+// ExecDesc allows unmarshalling complex subtype. Can be a slice of
+// cmd args, or a CmdDesc
 type ExecDesc struct {
 	Value interface{}
 }
-
-// HandlesDesc describes a handle name and invocable target.
-// The ExecDesc target can be an ArgSliceSpec, or a CmdDesc
-type HandlesDesc map[string]ExecDesc
 
 // Flags are the normalized FlagDesc
 type Flags map[string]*FlagSpec
@@ -54,6 +51,7 @@ type ArgSliceSpec []interface{}
 // Its SubCmd is an ExecDesc so it can be an ArgsSliceSpec or a CmdSpec
 // Its Flags can be a one line string flag or a FlagSpec
 type CmdDesc struct {
+	Cmd ArgSliceSpec `yaml:"cmd"`
 	// Args contain the args that get appended to the ExecEnvironment
 	Args ArgSliceSpec `yaml:"args"`
 	// SubCmd describes a sub-command of current command

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,9 +28,9 @@ type Config struct {
 	HideAssetsInHelp bool        `yaml:"hideAssetsInHelp"`
 }
 
-// ExecContext houses execution environments and global flags
+// ExecContext houses execution handles and global flags
 type ExecContext struct {
-	ExecEnv     map[string]ExecDesc `yaml:"environments"`
+	ExecEnv     map[string]ExecDesc `yaml:"handles"`
 	GlobalFlags map[string]FlagDesc `yaml:"flags"`
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -12,7 +12,7 @@ func TestConfigReader(t *testing.T) {
 	config := dedent.Dedent(`
     version: 1
     exec:
-      environments:
+      handles:
         hello: [python, -c, print("hello")]
         echo:
           cmd: [bash]

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -13,21 +13,21 @@ func TestConfigReader(t *testing.T) {
     version: 1
     exec:
       environments:
-        python -c:
-          hello: [print("hello")]
-        bash:
-          echo:
-            flags:
-              special-wrapper: 'happy new year: {{ .flag }}'
-            help: 'this is an echo adapter'
-            args: ['{{ flagValue "--special-wrapper" }}', '{{ arg 1 ""}}', '{{ arg 0 "" }}']
+        hello: [python, -c, print("hello")]
+        echo:
+          cmd: [bash]
+          flags:
+            special-wrapper: 'happy new year: {{ .flag }}'
+          help: 'this is an echo adapter'
+          args: ['{{ flagValue "--special-wrapper" }}', '{{ arg 1 ""}}', '{{ arg 0 "" }}']
 
-          with-flag:
-            flags:
-              flag-desc:
-                effect: "a"
-                shorthand: "f"
-                help: "flag-help"
+        with-flag:
+          cmd: []
+          flags:
+            flag-desc:
+              effect: "a"
+              shorthand: "f"
+              help: "flag-help"
 
     `)
 
@@ -35,14 +35,14 @@ func TestConfigReader(t *testing.T) {
 	err := c.Unmarshal([]byte(config))
 
 	require.Nil(t, err)
-	args := c.Exec.ExecEnv["python -c"]["hello"].Value.(ArgSliceSpec)
-	assert.Equal(t, "print(\"hello\")", args[0])
+	args := c.Exec.ExecEnv["hello"].Value.(ArgSliceSpec)
+	assert.Equal(t, "python", args[0])
 
-	cmdSpec := c.Exec.ExecEnv["bash"]["echo"].Value.(CmdDesc)
+	cmdSpec := c.Exec.ExecEnv["echo"].Value.(CmdDesc)
 	assert.Equal(t, `{{ flagValue "--special-wrapper" }}`, cmdSpec.Args[0])
 
 	assert.IsType(t, "", cmdSpec.Flags["special-wrapper"].Value)
 
-	cmdSpecWithFlags := c.Exec.ExecEnv["bash"]["with-flag"].Value.(CmdDesc)
+	cmdSpecWithFlags := c.Exec.ExecEnv["with-flag"].Value.(CmdDesc)
 	assert.IsType(t, FlagSpec{}, cmdSpecWithFlags.Flags["flag-desc"].Value)
 }

--- a/pkg/summon/run.go
+++ b/pkg/summon/run.go
@@ -240,7 +240,7 @@ func (d *Driver) execContext() (config.Flags, handles, error) {
 		for handle, execDesc := range d.config.Exec.ExecEnv {
 			cmdSpec, err := normalizeExecDesc(execDesc.Value)
 			if err != nil {
-				return nil, nil, fmt.Errorf("error in exec:environments:%s %s", handle, err.Error())
+				return nil, nil, fmt.Errorf("error in exec:handles:%s %s", handle, err.Error())
 			}
 			handles[handle] = cmdSpec
 

--- a/pkg/summon/run_test.go
+++ b/pkg/summon/run_test.go
@@ -231,7 +231,7 @@ exec:
   flags:
     config-root: 'CONFIG_ROOT=.'
 
-  environments:
+  handles:
     echo-pwd: ['echo', 'pwd:', '{{ env "PWD" | base }}']
 
     manifest:
@@ -333,7 +333,7 @@ func TestConstructCommandTree(t *testing.T) {
 		  flags:
 		    config-root: 'CONFIG_ROOT=.'
 
-		  environments:
+		  handles:
 		    manifest:
 		      cmd: [docker]
 		      help: 'render kubernetes manifests in build dir'
@@ -619,7 +619,7 @@ func TestFlagUsages2(t *testing.T) {
 		    global-flag:
 		      effect: 'global-flag-set'
 		      explicit: true
-		  environments:
+		  handles:
 		    a-command:
 		      cmd: [program]
 		      args: [-c]

--- a/pkg/summon/run_test.go
+++ b/pkg/summon/run_test.go
@@ -28,38 +28,39 @@ func TestRun(t *testing.T) {
 		helper    string
 		cmd       []string
 		enableRun bool
-		expect    []string
-		contains  []string
+		expect    [][]string
+		out       string
+		contains  [][]string
 		args      []string
 		wantErr   bool
 	}{
 		{
 			name:    "composite-invoker", // python -c
 			cmd:     []string{"hello"},
-			expect:  []string{"python -c print(\"hello from python!\")"},
+			expect:  [][]string{{"python", "-c", "print(\"hello from python!\")"}},
 			wantErr: false,
 		},
 		{
 			name:    "simple-invoker", // bash
 			cmd:     []string{"hello-bash"},
-			expect:  []string{"bash hello.sh"},
+			expect:  [][]string{{"bash", "hello.sh"}},
 			wantErr: false,
 		},
 		{
 			name:    "self-reference-invoker", // bash
 			cmd:     []string{"bash-self-ref"},
-			expect:  []string{fmt.Sprintf("bash %s", filepath.Join(os.TempDir(), "hello.sh"))},
+			expect:  [][]string{{"bash", filepath.Join(os.TempDir(), "hello.sh")}},
 			wantErr: false,
 		},
 		{
 			name:   "self-reference-run", // bash
 			helper: "TestSubCommandTemplateRunCall",
 			cmd:    []string{"run-example", "--help"},
-			expect: []string{
+			expect: [][]string{
 				// run first call (returns "hello from subcmd")
 				// should not have help active
-				"bash hello.sh",
-				"bash hello from subcmd --help", // actual run-example call with args
+				{"bash", "hello.sh"},
+				{"bash", "hello from subcmd", "--help"}, // actual run-example call with args
 			},
 			wantErr: false,
 		},
@@ -77,57 +78,57 @@ func TestRun(t *testing.T) {
 		{
 			name:    "renderable-invoker",
 			cmd:     []string{"docker"},
-			expect:  []string{"docker info"},
+			expect:  [][]string{{"docker", "info"}},
 			wantErr: false,
 		},
 		{
 			name:    "args-access",
 			cmd:     []string{"args"},
-			args:    []string{"a c", "b"},
-			expect:  []string{"bash args: a c b"},
+			args:    []string{"'a c'", "b"},
+			expect:  [][]string{{"bash", "args:", "a c", "b"}},
 			wantErr: false,
 		},
 		{
 			name:    "one-arg-access-remainder-passed",
 			cmd:     []string{"one-arg"},
-			args:    []string{"\"acce ssed\"", "remainder1", "remainder2"},
-			expect:  []string{"bash args: \"acce ssed\" remainder1 remainder2"},
+			args:    []string{"'acce ssed'", "remainder1", "remainder2"},
+			expect:  [][]string{{"bash", "args:", "acce ssed", "remainder1", "remainder2"}},
 			wantErr: false,
 		},
 		{
 			name:    "all-args-access-no-remainder-passed",
 			cmd:     []string{"all-args"},
 			args:    []string{"a", "b", "c", "d"},
-			expect:  []string{"bash args: a b c d"},
+			expect:  [][]string{{"bash", "args:", "a", "b", "c", "d"}},
 			wantErr: false,
 		},
 		{
 			name:     "osArgs-access",
 			cmd:      []string{"osArgs"},
-			contains: []string{"test"},
+			contains: [][]string{{"summon.test"}},
 			wantErr:  false,
 		},
 		{
-			cmd:      []string{"templateref"},
-			contains: []string{"bash 1.2.3"},
-			wantErr:  false,
+			cmd:     []string{"templateref"},
+			expect:  [][]string{{"bash", "1.2.3"}},
+			wantErr: false,
 		},
 		{
 			name:   "new-cmd-spec",
 			cmd:    []string{"overrides"},
-			expect: []string{"bash hello.sh"},
+			expect: [][]string{{"bash", "hello.sh"}},
 		},
 		{
 			name:   "new-cmd-spec-subcmd",
 			cmd:    []string{"overrides"},
 			args:   []string{"subcmd", "another"},
-			expect: []string{"bash hello.sh subcmd another"},
+			expect: [][]string{{"bash", "hello.sh", "subcmd", "another"}},
 		},
 		{
 			name:      "sub-cmd-with-run-enabled",
 			enableRun: true,
 			cmd:       []string{"run", "hello-bash"},
-			expect:    []string{"bash hello.sh"},
+			expect:    [][]string{{"bash", "hello.sh"}},
 		},
 		{
 			name:      "args-error-run-enabled",
@@ -154,12 +155,12 @@ func TestRun(t *testing.T) {
 		{
 			name:   "join-arguments",
 			args:   []string{"hello-join"},
-			expect: []string{"python -c print(\" these params will be joined \")"},
+			expect: [][]string{{"python", "-c", "print(\" these params will be joined \")"}},
 		},
 		{
 			name:   "join-then-dont-on-subarguments",
 			args:   []string{"hello-join", "non-inlined"},
-			expect: []string{"python -c print(\"hello\") # these are separate args -"},
+			expect: [][]string{{"python", "-c", "print(\"hello\")", "#", "these", "are", "separate", "args", "-"}},
 		},
 	}
 	for _, tt := range tests {
@@ -192,14 +193,28 @@ func TestRun(t *testing.T) {
 				assert.Len(t, c.Calls, 0)
 			} else {
 				if len(tt.expect) != 0 {
-					for i, e := range tt.expect {
-						assert.Equal(t, e, c.Calls[i].Args)
+					for nthCall, e := range tt.expect {
+						require.Less(t, nthCall, len(c.Calls), "%d out of range of calls, expected %s", nthCall, e)
+						assert.Equal(t, e, c.Calls[nthCall].Args)
 					}
 				}
 				if len(tt.contains) != 0 {
-					for i, e := range tt.contains {
-						assert.Contains(t, c.Calls[i].Args, e)
+					for nthCall, args := range tt.contains {
+						contains := false
+						for _, arg := range args {
+							for _, callArg := range c.Calls[nthCall].Args {
+								if strings.Contains(callArg, arg) {
+									contains = true
+									break
+								}
+							}
+							if contains {
+								break
+							}
+						}
+						assert.True(t, contains, "Args %s does not contain %s", c.Calls[nthCall].Args, args)
 					}
+
 				}
 			}
 		})
@@ -219,7 +234,7 @@ func TestSubCommandTemplateRunCall(t *testing.T) {
 		defer os.Exit(0)
 		testutil.WriteCall(testutil.MakeCall())
 
-		fmt.Fprint(os.Stdout, "hello from subcmd")
+		fmt.Fprint(os.Stdout, "\"hello from subcmd\"")
 	}
 }
 

--- a/pkg/summon/testdata/summon.config.yaml
+++ b/pkg/summon/testdata/summon.config.yaml
@@ -7,35 +7,35 @@ templates: >-
   {{ define "version" }}1.2.3{{ end }}
 exec:
   environments:
-    bash:
-      hello-bash: [ hello.sh ]
-      bash-self-ref: ['{{ summon "hello.sh" }}']
-      run-example: ['{{ run "hello-bash" }}']
-      args: ['args:', '{{ arg 0 "" }}']
-      one-arg: ['args:', '{{arg 0 "" }}']
-      all-args: ['args:', '{{ args }}']
-      osArgs: ['osArgs:', '{{ .osArgs }}']
-      templateref: ['{{ template "version"}}']
-      overrides:
-        help: 'help override'
-        args: [ hello.sh ]
-        subCmd:
-          subcmd:
-            help: "override subcmd help"
-            args: [hello.sh, subcmd]
+    hello-bash: [bash, hello.sh ]
+    bash-self-ref: [bash, '{{ summon "hello.sh" }}']
+    run-example: [bash, '{{ run "hello-bash" }}']
+    args: [bash, 'args:', '{{ arg 0 "" }}']
+    one-arg: [bash, 'args:', '{{arg 0 "" }}']
+    all-args: [bash, 'args:', '{{ args }}']
+    osArgs: [bash, 'osArgs:', '{{ .osArgs }}']
+    templateref: [bash, '{{ template "version"}}']
+    overrides:
+      cmd: [bash]
+      help: 'help override'
+      args: [ hello.sh ]
+      subCmd:
+        subcmd:
+          help: "override subcmd help"
+          args: [hello.sh, subcmd]
 
-    docker {{ lower "INFO" }}: # template example
-      docker: []
-    go run:
-      gohack: [github.com/rogpeppe/gohack@latest]
-    python -c:
-      hello: ['print("hello from python!")']
-      hello-join:
-        args: ['print("', 'these', 'params', 'will', 'be', 'joined', '")']
-        join: true
-        subCmd:
-          non-inlined:
-            args: ['print("hello")', '#', 'these', 'are', 'separate', 'args', '-']
-            join: false
+    docker: [docker, '{{ lower "INFO" }}'] # template example
+    gohack: [go, run, github.com/rogpeppe/gohack@latest]
+
+
+    hello: ['python', '-c', 'print("hello from python!")']
+    hello-join:
+      cmd: [python, -c]
+      args: ['print("', 'these', 'params', 'will', 'be', 'joined', '")']
+      join: true
+      subCmd:
+        non-inlined:
+          args: ['print("hello")', '#', 'these', 'are', 'separate', 'args', '-']
+          join: false
 
 

--- a/pkg/summon/testdata/summon.config.yaml
+++ b/pkg/summon/testdata/summon.config.yaml
@@ -28,14 +28,14 @@ exec:
     gohack: [go, run, github.com/rogpeppe/gohack@latest]
 
 
-    hello: ['python', '-c', 'print("hello from python!")']
+    hello: ['python', '-c', '"print(\"hello from python!\")"']
     hello-join:
       cmd: [python, -c]
-      args: ['print("', 'these', 'params', 'will', 'be', 'joined', '")']
+      args: ["'print(\"", 'these', 'params', 'will', 'be', 'joined', "\")'"]
       join: true
       subCmd:
         non-inlined:
-          args: ['print("hello")', '#', 'these', 'are', 'separate', 'args', '-']
+          args: ["'print(\"hello\")'", '#', 'these', 'are', 'separate', 'args', '-']
           join: false
 
 

--- a/pkg/summon/testdata/summon.config.yaml
+++ b/pkg/summon/testdata/summon.config.yaml
@@ -6,7 +6,7 @@ outputdir: "overridden_dir"
 templates: >-
   {{ define "version" }}1.2.3{{ end }}
 exec:
-  environments:
+  handles:
     hello-bash: [bash, hello.sh ]
     bash-self-ref: [bash, '{{ summon "hello.sh" }}']
     run-example: [bash, '{{ run "hello-bash" }}']


### PR DESCRIPTION
Breaking change.

The config has been simplified to warrant a `cmd:` field in `handles:` 

This allows conditional commands to be specified. One use case is that the consuming executables can specify docker environments when called from host, or remove the docker call when called inside the container.