### PR TITLE
adds destination when not able to scaffold

### DIFF
--- a/internal/scaffold/create.go
+++ b/internal/scaffold/create.go
@@ -28,7 +28,7 @@ func Create(destDir, modName, summonerName string, force bool) error {
 	empty, err := isEmptyDir(destDir)
 	if !force && !empty || err != nil {
 		if err == nil || !os.IsNotExist(err) {
-			return fmt.Errorf("destination directory is not empty")
+			return fmt.Errorf("destination directory is not empty: %s", destDir)
 		}
 	}
 


### PR DESCRIPTION
Error information was lacking the existing directory information, making it hard for the user to know what the problem is.