### PR TITLE
teach the summon templ func to allow dest

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,15 @@ bash /tmp/hello.sh
 > Note that `hello.sh` could also contain templates that will be
 rendered at instantiation time.
 
-##### Arg and Args Function
+Destination
+
+> new in v0.16.0
+>
+> The summon function takes an additional parameter specifying where the summoned
+> file should be written. If not specified, it will be written to the temp
+> directory.
+
+##### `{{ arg }}` and `{{ args }}` Function
 
 > New in v0.12.0
 
@@ -583,9 +591,9 @@ exec:
       cmd: *bash-c
       completion: '{{ (split ":" (run "bash-c" (printf "kubectl __complete %s ''%s''" (join " " (rest (initial args))) (last args))))._0 }}'
 
-    bash --norc --noprofile -c: # this is a simple bash environment to delegate calls
-      bash-c:
-        hidden: true
+    bash: # this is a simple bash environment to delegate calls
+      cmd: [bash, --norc, --noprofile, -c]
+      hidden: true
 ```
 
 #### Removing the run subcommand

--- a/pkg/summon/run_test.go
+++ b/pkg/summon/run_test.go
@@ -33,6 +33,7 @@ func TestRun(t *testing.T) {
 		contains  [][]string
 		args      []string
 		wantErr   bool
+		replaceFS bool
 	}{
 		{
 			name:    "composite-invoker", // python -c
@@ -47,10 +48,17 @@ func TestRun(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "self-reference-invoker", // bash
-			cmd:     []string{"bash-self-ref"},
-			expect:  [][]string{{"bash", filepath.Join(os.TempDir(), "hello.sh")}},
-			wantErr: false,
+			name:      "self-reference-invoker", // bash
+			cmd:       []string{"bash-self-ref"},
+			expect:    [][]string{{"bash", filepath.Join(os.TempDir(), "hello.sh")}},
+			wantErr:   false,
+			replaceFS: true,
+		},
+		{
+			name:      "summon-function-with-destination",
+			cmd:       []string{"summon-with-destination"},
+			expect:    [][]string{{"cat", filepath.Join("dest-dir", "hello.sh")}},
+			replaceFS: true,
 		},
 		{
 			name:   "self-reference-run", // bash
@@ -177,6 +185,10 @@ func TestRun(t *testing.T) {
 
 			if tt.helper == "" {
 				tt.helper = "TestSummonRunHelper"
+			}
+
+			if tt.replaceFS {
+				defer testutil.ReplaceFs()()
 			}
 
 			program := append([]string{"summon"}, tt.cmd...)

--- a/pkg/summon/summon.go
+++ b/pkg/summon/summon.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"text/template"
 
@@ -194,8 +195,14 @@ func summonFuncMap(d *Driver) template.FuncMap {
 			}
 			return strings.TrimSpace(b.String()), err
 		},
-		"summon": func(path string) (string, error) {
-			return d.Summon(Filename(path), Dest(os.TempDir()))
+		"summon": func(path string, arg ...any) (string, error) {
+			dest := os.TempDir()
+			if len(arg) > 0 {
+				if reflect.TypeOf(arg[0]).Kind() == reflect.String {
+					dest = arg[0].(string)
+				}
+			}
+			return d.Summon(Filename(path), Dest(dest))
 		},
 		"flagValue": func(flag string) (string, error) {
 			for _, toRender := range d.flagsToRender {

--- a/pkg/summon/testdata/summon.config.yaml
+++ b/pkg/summon/testdata/summon.config.yaml
@@ -10,6 +10,7 @@ exec:
     # These handles are setup for testing
     hello-bash: [bash, hello.sh ]
     bash-self-ref: [bash, '{{ summon "hello.sh" }}']
+    summon-with-destination: [cat, '{{ summon "hello.sh" "dest-dir" }}']
     run-example: [bash, '{{ run "hello-bash" }}']
     args: [bash, 'args:', '{{ arg 0 "" }}']
     one-arg: [bash, 'args:', '{{arg 0 "" }}']


### PR DESCRIPTION
The `summon` template function can now have a destination.

For example `{{ summon "embedded-file" "to-dir" }}` will render `embedded-file` inside the `to-dir` directory, forming `embedded-file/to-dir` path.